### PR TITLE
fix: filter symlink when checking if repo is clean

### DIFF
--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -57,7 +57,7 @@ impl Repo {
             .lines()
             .map(|l| l.trim())
             // filter symlinks
-            .filter(|l| l.starts_with("T "));
+            .filter(|l| !l.starts_with("T "));
         anyhow::ensure!(entries.next().is_none(), "the working directory of this project has uncommitted changes. Please commit or stash these changes:\n{output}");
         Ok(())
     }

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -53,8 +53,12 @@ impl Repo {
     /// Check if there are uncommitted changes.
     pub fn is_clean(&self) -> anyhow::Result<()> {
         let output = self.git(&["status", "--porcelain"])?;
-        let output = output.trim();
-        anyhow::ensure!(output.is_empty(), "the working directory of this project has uncommitted changes. Please commit or stash these changes:\n{output}");
+        let mut entries = output
+            .lines()
+            .map(|l| l.trim())
+            // filter symlinks
+            .filter(|l| l.starts_with("T "));
+        anyhow::ensure!(entries.next().is_none(), "the working directory of this project has uncommitted changes. Please commit or stash these changes:\n{output}");
         Ok(())
     }
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
-->
After I have introduced a symlink in this repo, release-plz has started failing. See [here](https://github.com/MarcoIeni/release-plz/commit/832838b7735d03045887f1ddf0187268100c69a0).
I am excluding symlink from `git status` check