### PR TITLE
refactor: inline the increment* functions to cut down dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,7 +1861,6 @@ dependencies = [
 name = "next_version"
 version = "0.1.6"
 dependencies = [
- "cargo-edit",
  "conventional_commit_parser",
  "semver",
 ]

--- a/crates/next_version/Cargo.toml
+++ b/crates/next_version/Cargo.toml
@@ -13,4 +13,3 @@ categories = ["development-tools", "parsing"]
 [dependencies]
 semver = "1.0.12"
 conventional_commit_parser = "0.9.4"
-cargo-edit = { version = "0.10.1", features = ["set-version"], default-features = false }

--- a/crates/next_version/src/version_increment.rs
+++ b/crates/next_version/src/version_increment.rs
@@ -1,4 +1,3 @@
-use cargo_edit::VersionExt;
 use conventional_commit_parser::commit::{CommitType, ConventionalCommit};
 use semver::Version;
 
@@ -65,12 +64,28 @@ impl VersionIncrement {
 
 impl VersionIncrement {
     pub fn bump(&self, version: &Version) -> Version {
-        let mut new_version = version.clone();
         match self {
-            Self::Major => new_version.increment_major(),
-            Self::Minor => new_version.increment_minor(),
-            Self::Patch => new_version.increment_patch(),
+            Self::Major => Version {
+                major: version.major + 1,
+                minor: 0,
+                patch: 0,
+                pre: semver::Prerelease::EMPTY,
+                build: semver::BuildMetadata::EMPTY,
+            },
+            Self::Minor => Version {
+                major: version.major,
+                minor: version.minor + 1,
+                patch: 0,
+                pre: semver::Prerelease::EMPTY,
+                build: semver::BuildMetadata::EMPTY,
+            },
+            Self::Patch => Version {
+                major: version.major,
+                minor: version.minor,
+                patch: version.patch + 1,
+                pre: semver::Prerelease::EMPTY,
+                build: semver::BuildMetadata::EMPTY,
+            },
         }
-        new_version
     }
 }


### PR DESCRIPTION
`cargo-edit` brought a lot of dependencies for 3 fairly easy functions.
Their inlined versions are still easy to read and extend if necessary.
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
-->
