### PR TITLE
Use the correct case for conflicting arguments

### DIFF
--- a/crates/release_plz/src/args/update.rs
+++ b/crates/release_plz/src/args/update.rs
@@ -31,12 +31,12 @@ pub struct Update {
     )]
     package: Option<String>,
     /// Don't create changelog.
-    #[clap(long, conflicts_with("release-date"))]
+    #[clap(long, conflicts_with("release_date"))]
     no_changelog: bool,
     /// Date of the release. Format: %Y-%m-%d. It defaults to current Utc date.
     #[clap(
         long,
-        conflicts_with("no-changelog"),
+        conflicts_with("no_changelog"),
         value_parser = NonEmptyStringValueParser::new()
     )]
     release_date: Option<String>,
@@ -45,7 +45,7 @@ pub struct Update {
     /// If unspecified, crates.io is used.
     #[clap(
         long,
-        conflicts_with("registry-project-manifest"),
+        conflicts_with("registry_project_manifest"),
         value_parser = NonEmptyStringValueParser::new()
     )]
     registry: Option<String>,
@@ -59,7 +59,7 @@ pub struct Update {
         long,
         env = "GIT_CLIFF_CONFIG",
         value_name = "PATH",
-        conflicts_with("no-changelog"),
+        conflicts_with("no_changelog"),
         value_parser = PathBufValueParser::new()
     )]
     changelog_config: Option<PathBuf>,


### PR DESCRIPTION
While running `release-plz generate-completions`, I got the following error:

```
thread 'main' panicked at 'Command::get_arg_conflicts_with: The passed arg conflicts with an arg unknown to the cmd', /build/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.0.18/src/builder/command.rs:3493:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is due to the recent [clap v4 upgrade](https://github.com/MarcoIeni/release-plz/commit/e4401a5a28de0af31e313b2cfeae1d8210d5875f). It is stated in the [changelog](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md) that arguments should be used as verbatim casing for `conflicts_with` and `requires`:

> *(derive)* Leave `Arg::id` as `verbatim` casing, requiring updating of string references to other args like in `conflicts_with` or `requires` (#3282)

This PR fixes this issue by updating the derived struct.

