### PR TITLE
fix: reintroduce github-token flag

### DIFF
--- a/crates/release_plz/src/args/release_pr.rs
+++ b/crates/release_plz/src/args/release_pr.rs
@@ -13,7 +13,7 @@ pub struct ReleasePr {
     #[clap(flatten)]
     pub update: Update,
     /// Git token used to create the pull request.
-    #[clap(long, value_parser = NonEmptyStringValueParser::new(), visible_alias = "github_token")]
+    #[clap(long, value_parser = NonEmptyStringValueParser::new(), visible_alias = "github-token")]
     git_token: String,
     /// Kind of git host where your project is hosted.
     #[clap(long, value_enum, default_value_t = GitBackendKind::Github)]


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
-->
