### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "cargo_utils"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3175,7 +3175,7 @@ checksum = "95059e91184749cb66be6dc994f67f182b6d897cb3df74a5bf66b5e709295fd8"
 
 [[package]]
 name = "test_logs"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "once_cell",
  "tracing",

--- a/crates/cargo_utils/CHANGELOG.md
+++ b/crates/cargo_utils/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/MarcoIeni/release-plz/compare/cargo_utils-v0.1.4...cargo_utils-v0.1.5) - 2023-01-13
+
+### Other
+- update dependencies
+
 ## [0.1.4](https://github.com/MarcoIeni/release-plz/compare/cargo_utils-v0.1.3...cargo_utils-v0.1.4) - 2022-12-26
 
 ### Other

--- a/crates/cargo_utils/Cargo.toml
+++ b/crates/cargo_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo_utils"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Utilities around cargo and Rust workspaces"
 repository = "https://github.com/MarcoIeni/release-plz/tree/main/crates/cargo_utils"

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["development-tools"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo_utils = { path = "../cargo_utils", version = "0.1.4" }
+cargo_utils = { path = "../cargo_utils", version = "0.1.5" }
 git_cmd = { path = "../git_cmd", version = "0.2.6" }
 next_version = { path = "../next_version", version = "0.2" }
 

--- a/crates/test_logs/CHANGELOG.md
+++ b/crates/test_logs/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/MarcoIeni/release-plz/compare/test_logs-v0.1.10...test_logs-v0.1.11) - 2023-01-13
+
+### Other
+- update dependencies
+
 ## [0.1.10] - 2022-11-04
 
 ### Other

--- a/crates/test_logs/Cargo.toml
+++ b/crates/test_logs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_logs"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "Library to see logs in tests"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `cargo_utils`: 0.1.4 -> 0.1.5
* `test_logs`: 0.1.10 -> 0.1.11
---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).