### PR TITLE
changelog: fix link to first change

### DIFF
--- a/crates/release_plz_core/src/repo_url.rs
+++ b/crates/release_plz_core/src/repo_url.rs
@@ -44,10 +44,17 @@ impl RepoUrl {
 
     /// Get GitHub release link
     pub fn gh_release_link(&self, prev_tag: &str, new_tag: &str) -> String {
-        format!(
-            "https://{}/{}/{}/compare/{prev_tag}...{new_tag}",
-            self.host, self.owner, self.name
-        )
+        if prev_tag == new_tag {
+            format!(
+                "https://{}/{}/{}/compare/{new_tag}",
+                self.host, self.owner, self.name
+            )
+        } else {
+            format!(
+                "https://{}/{}/{}/compare/{prev_tag}...{new_tag}",
+                self.host, self.owner, self.name
+            )
+        }
     }
 
     pub fn gitea_api_url(&self) -> String {


### PR DESCRIPTION
addresses bug described at: https://github.com/MarcoIeni/release-plz/issues/431

If this is the first release (we only have the current tag) the formats the changelog as: 
```
[0.0.1](https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.0.1)
```

Instead of 

```
[0.0.1](https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.1)
```

WIP: 
- Still missing unittests