### PR TITLE
chore: remove `octocrab` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,12 +42,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
-name = "arc-swap"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,12 +130,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "bitflags"
@@ -371,7 +359,6 @@ dependencies = [
  "iana-time-zone",
  "num-integer",
  "num-traits",
- "serde",
  "winapi",
 ]
 
@@ -1467,7 +1454,7 @@ checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
 dependencies = [
  "anyhow",
  "async-channel",
- "base64 0.13.1",
+ "base64",
  "futures-lite",
  "http",
  "infer",
@@ -1548,22 +1535,6 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "hyperx"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5617e92fc2f2501c3e2bc6ce547cad841adba2bae5b921c7e52510beca6d084c"
-dependencies = [
- "base64 0.13.1",
- "bytes",
- "http",
- "httpdate",
- "language-tags",
- "mime",
- "percent-encoding",
- "unicase",
 ]
 
 [[package]]
@@ -1725,20 +1696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebtoken"
-version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
-dependencies = [
- "base64 0.13.1",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
 name = "kstring"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,12 +1712,6 @@ checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
 dependencies = [
  "static_assertions",
 ]
-
-[[package]]
-name = "language-tags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -1988,17 +1939,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,31 +1974,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d864c91689fdc196779b98dba0aceac6118594c2df6ee5d943eb6a8df4d107a"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "octocrab"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f21c2c98d2c7556e4bbacac59eb3d7449ef6a9b0f14d3aa348f692f4e851f6"
-dependencies = [
- "arc-swap",
- "async-trait",
- "base64 0.20.0",
- "bytes",
- "cfg-if",
- "chrono",
- "either",
- "hyperx",
- "jsonwebtoken",
- "once_cell",
- "reqwest",
- "secrecy",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "snafu",
- "url",
 ]
 
 [[package]]
@@ -2183,15 +2098,6 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
-name = "pem"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c64931a1a212348ec4f3b4362585eca7159d0d09cbdf4a7f74f02173596fd4"
-dependencies = [
- "base64 0.13.1",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -2579,7 +2485,6 @@ dependencies = [
  "git-url-parse",
  "git_cmd",
  "next_version",
- "octocrab",
  "parse-changelog",
  "reqwest",
  "secrecy",
@@ -2610,7 +2515,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2646,21 +2551,6 @@ name = "retain_mut"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi",
-]
 
 [[package]]
 name = "roff"
@@ -2870,15 +2760,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b04f22b563c91331a10074bda3dd5492e3cc39d56bd557e91c0af42b6c7341"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_qs"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,18 +2830,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
-name = "simple_asn1"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror",
- "time",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,29 +2882,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "snafu"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0656e7e3ffb70f6c39b3c2a86332bb74aa3c679da781642590f3c1118c5045"
-dependencies = [
- "backtrace",
- "doc-comment",
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "475b3bbe5245c26f2d8a6f62d67c1f30eb9fffeccee721c45d162c3ebbdf81b2"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3044,12 +2890,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "static_assertions"
@@ -3219,33 +3059,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
-dependencies = [
- "itoa",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
-
-[[package]]
-name = "time-macros"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
-dependencies = [
- "time-core",
 ]
 
 [[package]]
@@ -3559,12 +3372,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "url"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,7 +3657,7 @@ checksum = "12316b50eb725e22b2f6b9c4cbede5b7b89984274d113a7440c86e5c3fc6f99b"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "base64 0.13.1",
+ "base64",
  "deadpool",
  "futures",
  "futures-timer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,11 +1049,10 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -1563,11 +1562,10 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -1819,12 +1817,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -2101,9 +2093,9 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
@@ -3373,9 +3365,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "url"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ fs_extra = "1.2.0"
 git-cliff = { version = "0.8.1", default_features = false }
 git-cliff-core = "0.8.1"
 git-url-parse = "0.4.4"
-octocrab = "0.18.1"
 once_cell = "1.17.0"
 parse-changelog = { version = "0.5.3", default-features = false }
 reqwest = "0.11.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,6 @@ toml_edit = { version = "0.17.1", features = ["easy", "perf"] }
 tracing = "0.1.37"
 tracing-log = "0.1.3"
 tracing-subscriber = "0.3.16"
-url = "2.3.0"
+url = { version = "2.3.1", default-features = false }
 walkdir = "2.3.2"
 wiremock = "0.5.17"

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -31,7 +31,7 @@ secrecy.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tempfile.workspace = true
 tracing.workspace = true
-url.workspace = true
+url = { workspace = true, features = ["serde"] }
 walkdir.workspace = true
 toml_edit.workspace = true
 serde_json.workspace = true

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -25,7 +25,6 @@ fs_extra.workspace = true
 git-cliff.workspace = true
 git-cliff-core.workspace = true
 git-url-parse.workspace = true
-octocrab.workspace = true
 parse-changelog.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 secrecy.workspace = true
@@ -35,6 +34,7 @@ tracing.workspace = true
 url.workspace = true
 walkdir.workspace = true
 toml_edit.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 git_cmd = { path = "../git_cmd", features = ["test_fixture"] }

--- a/crates/release_plz_core/src/backend.rs
+++ b/crates/release_plz_core/src/backend.rs
@@ -2,7 +2,7 @@ use crate::gitea_client::{Gitea, GiteaClient};
 use crate::github_client::GitHubClient;
 use crate::pr::Pr;
 use crate::GitHub;
-use tracing::instrument;
+use tracing::{info, instrument};
 
 #[derive(Debug)]
 pub enum GitBackend {
@@ -34,9 +34,12 @@ impl<'a> GitClient<'a> {
 
     #[instrument(skip(pr))]
     pub async fn open_pr(&self, pr: &Pr) -> anyhow::Result<()> {
-        match self {
+        let html_url = match self {
             GitClient::GitHub(g) => g.open_pr(pr).await,
             GitClient::Gitea(g) => g.open_pr(pr).await,
-        }
+        }?;
+
+        info!("opened pr: {}", html_url);
+        Ok(())
     }
 }

--- a/crates/release_plz_core/src/gitea_client.rs
+++ b/crates/release_plz_core/src/gitea_client.rs
@@ -12,6 +12,7 @@ pub struct GiteaClient<'a> {
     gitea: &'a Gitea,
     client: reqwest::Client,
 }
+
 #[derive(Deserialize)]
 struct GiteaPr {
     html_url: Url,

--- a/crates/release_plz_core/src/gitea_client.rs
+++ b/crates/release_plz_core/src/gitea_client.rs
@@ -1,8 +1,8 @@
 use crate::pr::Pr;
 use crate::RepoUrl;
 use anyhow::bail;
-use reqwest::header::HeaderValue;
 use reqwest::Method;
+use reqwest::{header::HeaderValue, Url};
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument};
@@ -11,6 +11,10 @@ use tracing::{debug, instrument};
 pub struct GiteaClient<'a> {
     gitea: &'a Gitea,
     client: reqwest::Client,
+}
+#[derive(Deserialize)]
+struct GiteaPr {
+    html_url: Url,
 }
 
 impl<'a> GiteaClient<'a> {
@@ -80,7 +84,7 @@ impl<'a> GiteaClient<'a> {
     }
 
     #[instrument(skip(pr))]
-    pub async fn open_pr(&self, pr: &Pr) -> anyhow::Result<()> {
+    pub async fn open_pr(&self, pr: &Pr) -> anyhow::Result<Url> {
         let req_body = OpenPrBody {
             title: &pr.title,
             body: &pr.body,
@@ -104,8 +108,14 @@ impl<'a> GiteaClient<'a> {
             "Opening PR in {}/{}: {:?}",
             self.gitea.owner, self.gitea.repo, req
         );
-        self.client.execute(req).await?.error_for_status()?;
-        Ok(())
+        let pr: GiteaPr = self
+            .client
+            .execute(req)
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(pr.html_url)
     }
 
     fn get_token_header(&self) -> anyhow::Result<HeaderValue> {

--- a/crates/release_plz_core/src/github_client.rs
+++ b/crates/release_plz_core/src/github_client.rs
@@ -48,6 +48,7 @@ impl<'a> GitHubClient<'a> {
         let headers = default_headers(&github.token)?;
 
         let client = reqwest::Client::builder()
+            .user_agent("release-plz")
             .default_headers(headers)
             .build()
             .context("can't build GitHub client")?;

--- a/crates/release_plz_core/src/github_client.rs
+++ b/crates/release_plz_core/src/github_client.rs
@@ -74,7 +74,7 @@ impl<'a> GitHubClient<'a> {
         };
         self.client
             .post(format!(
-                "{}/repos/{}/{}/releases",
+                "{}repos/{}/{}/releases",
                 self.base_url, self.github.owner, self.github.repo
             ))
             .json(&create_release_options)
@@ -87,7 +87,7 @@ impl<'a> GitHubClient<'a> {
 
     pub fn pulls_url(&self) -> String {
         format!(
-            "{}/repos/{}/{}/pulls",
+            "{}repos/{}/{}/pulls",
             self.base_url, self.github.owner, self.github.repo
         )
     }

--- a/crates/release_plz_core/src/github_client.rs
+++ b/crates/release_plz_core/src/github_client.rs
@@ -1,10 +1,9 @@
 use anyhow::Context;
-use octocrab::{
-    models::{repos, IssueState},
-    params, Octocrab, OctocrabBuilder,
-};
+use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::{ExposeSecret, SecretString};
-use tracing::{info, instrument, Span};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tracing::instrument;
 use url::Url;
 
 use crate::pr::Pr;
@@ -12,117 +11,140 @@ use crate::pr::Pr;
 #[derive(Debug)]
 pub struct GitHubClient<'a> {
     github: &'a GitHub,
-    client: Octocrab,
+    client: reqwest::Client,
+    base_url: Url,
+}
+
+const GITHUB_BASE_URL: &str = "https://api.github.com";
+
+fn default_headers(token: &SecretString) -> anyhow::Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    let header_value: HeaderValue = format!("Bearer {}", token.expose_secret())
+        .parse()
+        .context("invalid GitHub token")?;
+    headers.insert(
+        reqwest::header::ACCEPT,
+        HeaderValue::from_static("application/vnd.github+json"),
+    );
+    headers.insert(reqwest::header::AUTHORIZATION, header_value);
+    Ok(headers)
+}
+
+#[derive(Serialize)]
+pub struct CreateReleaseOption<'a> {
+    tag_name: &'a str,
+    body: &'a str,
+    name: &'a str,
+}
+
+#[derive(Deserialize)]
+struct GitHubPr {
+    number: u64,
+    html_url: Url,
 }
 
 impl<'a> GitHubClient<'a> {
     pub fn new(github: &'a GitHub) -> anyhow::Result<Self> {
-        let mut octocrab_builder =
-            OctocrabBuilder::new().personal_token(github.token.expose_secret().clone());
+        let headers = default_headers(&github.token)?;
 
-        if let Some(base_url) = &github.base_url {
-            octocrab_builder = octocrab_builder
-                .base_url(base_url.clone())
-                .context("Invalid GitHub base url")?;
-        }
-
-        let client = octocrab_builder
+        let client = reqwest::Client::builder()
+            .user_agent("release-plz")
+            .default_headers(headers)
             .build()
-            .context("Failed to build GitHub client")?;
+            .context("can't build GitHub client")?;
 
-        Ok(Self { github, client })
+        let base_url = github
+            .base_url
+            .clone()
+            .unwrap_or_else(|| Url::parse(GITHUB_BASE_URL).unwrap());
+
+        Ok(Self {
+            github,
+            client,
+            base_url,
+        })
     }
 
     /// Creates a GitHub release.
-    pub async fn create_release(&self, tag: &str, body: &str) -> anyhow::Result<repos::Release> {
+    pub async fn create_release(&self, tag: &str, body: &str) -> anyhow::Result<()> {
+        let create_release_options = CreateReleaseOption {
+            tag_name: tag,
+            body,
+            name: tag,
+        };
         self.client
-            .repos(&self.github.owner, &self.github.repo)
-            .releases()
-            .create(tag)
-            .name(tag)
-            .body(body)
+            .post(format!(
+                "{}/repos/{}/{}/releases",
+                self.base_url, self.github.owner, self.github.repo
+            ))
+            .json(&create_release_options)
             .send()
             .await
-            .context("Failed to create release")
+            .context("Failed to create release")?
+            .error_for_status()?;
+        Ok(())
+    }
+
+    pub fn pulls_url(&self) -> String {
+        format!(
+            "{}/repos/{}/{}/pulls",
+            self.base_url, self.github.owner, self.github.repo
+        )
     }
 
     /// Close all Prs which branch starts with the given `branch_prefix`.
     pub async fn close_prs_on_branches(&self, branch_prefix: &str) -> anyhow::Result<()> {
-        let pulls = self.client.pulls(&self.github.owner, &self.github.repo);
+        let release_prs: Vec<GitHubPr> = self
+            .client
+            .get(self.pulls_url())
+            .query(&[("state", "open"), ("base", branch_prefix)])
+            .send()
+            .await
+            .context("Failed to retrieve branches")?
+            .error_for_status()?
+            .json()
+            .await
+            .context("failed to parse pr")?;
 
-        let mut i: u32 = 1;
-        let page_size = 30;
-        loop {
-            let prs = pulls
-                .list()
-                .state(params::State::Open)
-                .per_page(page_size)
-                .page(i)
-                .send()
-                .await
-                .context("Failed to retrieve PRs")?
-                .take_items();
-            let release_prs = prs
-                .iter()
-                .filter(|&pr| pr.head.ref_field.starts_with(branch_prefix))
-                .map(|pr| pr.number);
-            for release_pr in release_prs {
-                self.close_pr(release_pr).await?;
-            }
-
-            if prs.len() < page_size as usize {
-                break;
-            }
-            i += 1;
+        for pr in release_prs {
+            self.close_pr(pr.number).await?;
         }
+
         Ok(())
     }
 
     async fn close_pr(&self, pr_number: u64) -> anyhow::Result<()> {
         self.client
-            .issues(&self.github.owner, &self.github.repo)
-            .update(pr_number)
-            .state(IssueState::Closed)
+            .patch(format!("{}/{}", self.pulls_url(), pr_number))
+            .json(&json!({
+                "state": "closed",
+            }))
             .send()
             .await
             .with_context(|| format!("cannot close pr {pr_number}"))?;
         Ok(())
     }
 
-    #[instrument(
-        fields(
-            default_branch = tracing::field::Empty,
-        ),
-        skip(pr)
-    )]
-    pub async fn open_pr(&self, pr: &Pr) -> anyhow::Result<()> {
-        let default_branch = self
+    #[instrument(skip(self, pr))]
+    pub async fn open_pr(&self, pr: &Pr) -> anyhow::Result<Url> {
+        let pr: GitHubPr = self
             .client
-            .repos(&self.github.owner, &self.github.repo)
-            .get()
-            .await
-            .context(format!(
-                "failed to retrieve GitHub repository {}/{}",
-                self.github.owner, self.github.repo
-            ))?
-            .default_branch
-            .context("failed to retrieve default branch")?;
-        Span::current().record("default_branch", default_branch.as_str());
-
-        let pr = self
-            .client
-            .pulls(&self.github.owner, &self.github.repo)
-            .create(&pr.title, &pr.branch, default_branch)
-            .body(&pr.body)
+            .post(self.pulls_url())
+            .json(&json!({
+                "title": pr.title,
+                "body": pr.body,
+                "base": pr.base_branch,
+                "head": pr.branch
+            }))
             .send()
             .await
-            .context("Failed to open PR")?;
+            .context("Failed to open PR")?
+            .error_for_status()?
+            .json()
+            .await
+            .context("Failed to parse PR")?;
 
-        if let Some(url) = pr.html_url {
-            info!("opened pr: {}", url);
-        }
-
-        Ok(())
+        Ok(pr.html_url)
     }
 }
 

--- a/crates/release_plz_core/src/github_client.rs
+++ b/crates/release_plz_core/src/github_client.rs
@@ -48,7 +48,6 @@ impl<'a> GitHubClient<'a> {
         let headers = default_headers(&github.token)?;
 
         let client = reqwest::Client::builder()
-            .user_agent("release-plz")
             .default_headers(headers)
             .build()
             .context("can't build GitHub client")?;

--- a/crates/release_plz_core/src/release.rs
+++ b/crates/release_plz_core/src/release.rs
@@ -192,7 +192,7 @@ async fn publish_release(
     if repo_url.is_on_github() {
         let github = GitHub::new(repo_url.clone().owner, repo_url.clone().name, git_token);
         let github_client = GitHubClient::new(&github)?;
-        let _page = github_client.create_release(&git_tag, release_body).await?;
+        github_client.create_release(&git_tag, release_body).await?;
     }
     Ok(())
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
-->
Reasons:
- it removes 18 dependencies 
- it unblocks https://github.com/MarcoIeni/release-plz/issues/420
- we support Gitea, too and the APIs are almost the same. So we need to implement the HTTP calls manually anyway
- we can implement a retry mechanism easily with `reqwest-middleware` for both gitea and github