### PR TITLE
fix: don't mark releases as latest if multiple public packages

### DIFF
--- a/crates/release_plz_core/src/github_client.rs
+++ b/crates/release_plz_core/src/github_client.rs
@@ -35,6 +35,7 @@ pub struct CreateReleaseOption<'a> {
     tag_name: &'a str,
     body: &'a str,
     name: &'a str,
+    make_latest: &'a str,
 }
 
 #[derive(Deserialize)]
@@ -73,11 +74,17 @@ impl<'a> GitHubClient<'a> {
     }
 
     /// Creates a GitHub release.
-    pub async fn create_release(&self, tag: &str, body: &str) -> anyhow::Result<()> {
+    pub async fn create_release(
+        &self,
+        tag: &str,
+        body: &str,
+        make_latest: bool,
+    ) -> anyhow::Result<()> {
         let create_release_options = CreateReleaseOption {
             tag_name: tag,
             body,
             name: tag,
+            make_latest: &make_latest.to_string(),
         };
         self.client
             .post(format!(

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -187,7 +187,7 @@ pub struct Project {
     manifest_dir: PathBuf,
     /// The project contains more than one public package.
     /// Not affected by `single_package` option.
-    contains_multiple_pub_packages: bool,
+    pub contains_multiple_pub_packages: bool,
 }
 
 impl Project {


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
-->
