### PR TITLE
feat(release): allow passing flags to cargo publish

### DIFF
--- a/crates/release_plz/src/args/release.rs
+++ b/crates/release_plz/src/args/release.rs
@@ -29,6 +29,9 @@ pub struct Release {
     /// Publish GitHub release for the created git tag.
     #[clap(long)]
     pub git_release: bool,
+    /// Flags to pass to `cargo publish`
+    #[clap(long)]
+    pub publish_flags: Option<String>,
     /// GitHub repository url.
     #[clap(long, value_parser = NonEmptyStringValueParser::new())]
     pub repo_url: Option<String>,
@@ -59,6 +62,7 @@ impl TryFrom<Release> for ReleaseRequest {
             dry_run: r.dry_run,
             git_release,
             repo_url: r.repo_url,
+            publish_flags: r.publish_flags,
         })
     }
 }

--- a/crates/release_plz/src/args/release.rs
+++ b/crates/release_plz/src/args/release.rs
@@ -30,8 +30,8 @@ pub struct Release {
     #[clap(long)]
     pub git_release: bool,
     /// Flags to pass to `cargo publish`
-    #[clap(long)]
-    pub publish_flags: Option<String>,
+    #[clap(long, value_delimiter = ' ')]
+    pub publish_flags: Vec<String>,
     /// GitHub repository url.
     #[clap(long, value_parser = NonEmptyStringValueParser::new())]
     pub repo_url: Option<String>,

--- a/crates/release_plz_core/src/release.rs
+++ b/crates/release_plz_core/src/release.rs
@@ -34,7 +34,7 @@ pub struct ReleaseRequest {
     /// GitHub repo URL.
     pub repo_url: Option<String>,
     /// Extra flags for `cargo publish`.
-    pub publish_flags: Option<String>,
+    pub publish_flags: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -109,11 +109,9 @@ async fn release_package(
     git_tag: String,
 ) -> anyhow::Result<()> {
     let mut args = vec!["publish"];
-    if let Some(publish_flags) = &input.publish_flags {
-        for flag in publish_flags.split(" ") {
-            args.push(flag);
-        }
-    }   
+    for flag in &input.publish_flags {
+        args.push(flag);
+    }
     args.push("--color");
     args.push("always");
     args.push("--manifest-path");

--- a/crates/release_plz_core/src/release.rs
+++ b/crates/release_plz_core/src/release.rs
@@ -33,7 +33,7 @@ pub struct ReleaseRequest {
     pub git_release: Option<GitRelease>,
     /// GitHub repo URL.
     pub repo_url: Option<String>,
-    /// Extra flags for  `cargo publish`.
+    /// Extra flags for `cargo publish`.
     pub publish_flags: Option<String>,
 }
 

--- a/crates/release_plz_core/src/release.rs
+++ b/crates/release_plz_core/src/release.rs
@@ -33,6 +33,8 @@ pub struct ReleaseRequest {
     pub git_release: Option<GitRelease>,
     /// GitHub repo URL.
     pub repo_url: Option<String>,
+    /// Extra flags for  `cargo publish`.
+    pub publish_flags: Option<String>,
 }
 
 #[derive(Debug)]
@@ -110,6 +112,11 @@ async fn release_package(
     args.push("--color");
     args.push("always");
     args.push("--manifest-path");
+    if let Some(publish_flags) = &input.publish_flags {
+        for flag in publish_flags.split(" ") {
+            args.push(flag);
+        }
+    }
     args.push(package.manifest_path.as_ref());
     if let Some(token) = &input.token {
         args.push("--token");

--- a/crates/release_plz_core/src/release.rs
+++ b/crates/release_plz_core/src/release.rs
@@ -109,14 +109,14 @@ async fn release_package(
     git_tag: String,
 ) -> anyhow::Result<()> {
     let mut args = vec!["publish"];
-    args.push("--color");
-    args.push("always");
-    args.push("--manifest-path");
     if let Some(publish_flags) = &input.publish_flags {
         for flag in publish_flags.split(" ") {
             args.push(flag);
         }
-    }
+    }   
+    args.push("--color");
+    args.push("always");
+    args.push("--manifest-path");
     args.push(package.manifest_path.as_ref());
     if let Some(token) = &input.token {
         args.push("--token");


### PR DESCRIPTION
This allows for you to be able to pass any flags you want when running `plz-release publish` to `cargo publish`.

Fixes #515