### PR TITLE
chore: rename field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .DS_Store
 .vscode
 .idea
+/vendor

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -43,9 +43,9 @@ pub struct UpdateRequest {
     /// Allow dirty working directories to be updated.
     /// The uncommitted changes will be part of the update.
     allow_dirty: bool,
-    /// If present, the new changelog entry contains a link to the diff between the old and new version.
+    /// Repository Url. If present, the new changelog entry contains a link to the diff between the old and new version.
     /// Format: `https://{repo_host}/{repo_owner}/{repo_name}/compare/{old_tag}...{new_tag}`.
-    github_repo: Option<RepoUrl>,
+    repo_url: Option<RepoUrl>,
 }
 
 #[derive(Debug, Clone)]
@@ -73,7 +73,7 @@ impl UpdateRequest {
             registry: None,
             update_dependencies: false,
             allow_dirty: false,
-            github_repo: None,
+            repo_url: None,
         })
     }
 
@@ -115,7 +115,7 @@ impl UpdateRequest {
 
     pub fn with_repo_url(self, repo_url: RepoUrl) -> Self {
         Self {
-            github_repo: Some(repo_url),
+            repo_url: Some(repo_url),
             ..self
         }
     }
@@ -368,7 +368,7 @@ impl Updater<'_> {
                 .git_tag(&package.name, &package.version.to_string());
             let next_tag = self.project.git_tag(&package.name, &version.to_string());
             self.req
-                .github_repo
+                .repo_url
                 .as_ref()
                 .map(|r| r.gh_release_link(&prev_tag, &next_tag))
         };


### PR DESCRIPTION
- ignore vendor directory
- rename github repo field

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
-->
