### PR TITLE
fix: force git stash

### DIFF
--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -139,6 +139,11 @@ impl Repo {
         git_in_dir(&self.directory, args)
     }
 
+    pub fn checkout_stash(&self) -> anyhow::Result<()> {
+        self.git(&["checkout", "stash", "--", "."])?;
+        Ok(())
+    }
+
     /// Checkout to the latest commit.
     pub fn checkout_last_commit_at_path(&self, path: &Path) -> anyhow::Result<()> {
         let previous_commit = self.last_commit_at_path(path)?;

--- a/crates/release_plz_core/src/release_pr.rs
+++ b/crates/release_plz_core/src/release_pr.rs
@@ -146,12 +146,12 @@ fn update_pr(pr: &GitHubPr, commits_number: usize, repository: &Repo) -> anyhow:
 
     reset_branch(pr, commits_number, repository).map_err(|e| {
         // restore local work
-        if let Err(e) = repository.git(&["stash", "pop"]) {
+        if let Err(e) = repository.checkout_stash() {
             tracing::error!("cannot restore local work: {}", e);
         }
         e
     })?;
-    repository.git(&["stash", "pop"])?;
+    repository.checkout_stash()?;
     force_push(pr, repository)?;
     info!("updated pr {}", pr.html_url);
     Ok(())

--- a/crates/release_plz_core/src/release_pr.rs
+++ b/crates/release_plz_core/src/release_pr.rs
@@ -151,6 +151,9 @@ fn update_pr(pr: &GitHubPr, commits_number: usize, repository: &Repo) -> anyhow:
         }
         e
     })?;
+    if let Err(e) = repository.git(&["rebase", repository.default_branch()]) {
+        tracing::error!("cannot rebase from default branch: {}", e);
+    }
     repository.checkout_stash()?;
     force_push(pr, repository)?;
     info!("updated pr {}", pr.html_url);

--- a/crates/release_plz_core/src/release_pr.rs
+++ b/crates/release_plz_core/src/release_pr.rs
@@ -151,10 +151,6 @@ fn update_pr(pr: &GitHubPr, commits_number: usize, repository: &Repo) -> anyhow:
         }
         e
     })?;
-    // Update PR branch with latest changes from the default branch.
-    if let Err(e) = repository.git(&["rebase", repository.default_branch()]) {
-        tracing::error!("cannot rebase from default branch: {}", e);
-    }
     repository.checkout_stash()?;
     force_push(pr, repository)?;
     info!("updated pr {}", pr.html_url);
@@ -172,6 +168,12 @@ fn reset_branch(pr: &GitHubPr, commits_number: usize, repository: &Repo) -> anyh
 
     let head = format!("HEAD~{commits_number}");
     repository.git(&["reset", "--hard", &head])?;
+
+    // Update PR branch with latest changes from the default branch.
+    if let Err(e) = repository.git(&["rebase", repository.default_branch()]) {
+        tracing::error!("cannot rebase from default branch: {}", e);
+    }
+
     Ok(())
 }
 

--- a/crates/release_plz_core/src/release_pr.rs
+++ b/crates/release_plz_core/src/release_pr.rs
@@ -151,6 +151,7 @@ fn update_pr(pr: &GitHubPr, commits_number: usize, repository: &Repo) -> anyhow:
         }
         e
     })?;
+    // Update PR branch with latest changes from the default branch.
     if let Err(e) = repository.git(&["rebase", repository.default_branch()]) {
         tracing::error!("cannot rebase from default branch: {}", e);
     }

--- a/crates/release_plz_core/src/release_pr.rs
+++ b/crates/release_plz_core/src/release_pr.rs
@@ -163,8 +163,8 @@ fn reset_branch(pr: &GitHubPr, commits_number: usize, repository: &Repo) -> anyh
 
     if repository.checkout(pr.branch()).is_err() {
         repository.git(&["pull"])?;
+        repository.checkout(pr.branch())?;
     };
-    repository.checkout(pr.branch())?;
 
     let head = format!("HEAD~{commits_number}");
     repository.git(&["reset", "--hard", &head])?;


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
-->
[This](https://github.com/MarcoIeni/release-plz/commit/55172e4b4bfe9e01a6f8bbddc410783521cd0e90) commit failed because there were merge conflicts when doing `git stash pop`.
We only do `git stash pop` when the PR wasn't edited by a human, so it's fine to overwrite the changes made by bots (including release-plz itself).