### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "cargo_utils"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "next_version"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "conventional_commit_parser",
  "semver",
@@ -2490,7 +2490,7 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "release-plz"
-version = "0.2.49"
+version = "0.2.50"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "release_plz_core"
-version = "0.4.21"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "cargo",

--- a/crates/cargo_utils/CHANGELOG.md
+++ b/crates/cargo_utils/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/MarcoIeni/release-plz/compare/cargo_utils-v0.1.11...cargo_utils-v0.1.12) - 2023-02-26
+
+### Added
+- cargo-semver-checks integration
+
 ## [0.1.11](https://github.com/MarcoIeni/release-plz/compare/cargo_utils-v0.1.10...cargo_utils-v0.1.11) - 2023-02-20
 
 ### Other

--- a/crates/cargo_utils/Cargo.toml
+++ b/crates/cargo_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo_utils"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "Utilities around cargo and Rust workspaces"
 repository = "https://github.com/MarcoIeni/release-plz/tree/main/crates/cargo_utils"

--- a/crates/next_version/CHANGELOG.md
+++ b/crates/next_version/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/MarcoIeni/release-plz/compare/next_version-v0.2.0...next_version-v0.2.1) - 2023-02-26
+
+### Added
+- cargo-semver-checks integration
+
 ## [0.2.0](https://github.com/MarcoIeni/release-plz/compare/next_version-v0.1.10...next_version-v0.2.0) - 2023-01-11
 
 ### Added

--- a/crates/next_version/Cargo.toml
+++ b/crates/next_version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "next_version"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Determine next semantic version based on conventional commits"
 license = "MIT OR Apache-2.0"

--- a/crates/release_plz/CHANGELOG.md
+++ b/crates/release_plz/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.50](https://github.com/MarcoIeni/release-plz/compare/release-plz-v0.2.49...release-plz-v0.2.50) - 2023-02-26
+
+### Added
+- cargo-semver-checks integration
+
+### Other
+- wip
+- wip
+
 ## [0.2.49](https://github.com/MarcoIeni/release-plz/compare/release-plz-v0.2.48...release-plz-v0.2.49) - 2023-02-20
 
 ### Other

--- a/crates/release_plz/Cargo.toml
+++ b/crates/release_plz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release-plz"
-version = "0.2.49"
+version = "0.2.50"
 edition = "2021"
 description = "Update version and changelog based on semantic versioning and conventional commits"
 repository = "https://github.com/MarcoIeni/release-plz"
@@ -13,7 +13,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 git_cmd = { path = "../git_cmd", version = "0.2.15" }
-release_plz_core = { path = "../release_plz_core", version = "0.4.21" }
+release_plz_core = { path = "../release_plz_core", version = "0.5.0" }
 
 anyhow.workspace = true
 chrono = { workspace = true, features = ["clock"] }

--- a/crates/release_plz_core/CHANGELOG.md
+++ b/crates/release_plz_core/CHANGELOG.md
@@ -6,6 +6,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/MarcoIeni/release-plz/compare/release_plz_core-v0.4.21...release_plz_core-v0.5.0) - 2023-02-26
+
+### Added
+- cargo-semver-checks integration
+
+### Fixed
+- fix
+
+### Other
+- wip
+- wip
+- wip
+- wip
+- wip
+- wip
+- wip
+- wip
+- wip
+- different checkmark
+- wip
+- wip
+- switch to enum
+- refactor
+- check
+- wip
+- wip
+- wip
+- wip
+- fmt
+
 ## [0.4.21](https://github.com/MarcoIeni/release-plz/compare/release_plz_core-v0.4.20...release_plz_core-v0.4.21) - 2023-02-20
 
 ### Other

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release_plz_core"
-version = "0.4.21"
+version = "0.5.0"
 edition = "2021"
 description = "Update version and changelog based on semantic versioning and conventional commits"
 repository = "https://github.com/MarcoIeni/release-plz/tree/main/crates/release_plz_core"
@@ -11,7 +11,7 @@ categories = ["development-tools"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo_utils = { path = "../cargo_utils", version = "0.1.11" }
+cargo_utils = { path = "../cargo_utils", version = "0.1.12" }
 git_cmd = { path = "../git_cmd", version = "0.2.15" }
 next_version = { path = "../next_version", version = "0.2" }
 


### PR DESCRIPTION
## 🤖 New release
* `cargo_utils`: 0.1.11 -> 0.1.12 (✓ API compatible changes)
* `next_version`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `release-plz`: 0.2.49 -> 0.2.50
* `release_plz_core`: 0.4.21 -> 0.5.0 (⚠️ API breaking changes)

### ⚠️ `release_plz_core` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.18.3/src/lints/constructible_struct_adds_field.ron

Failed in:
  field UpdateResult.semver_check in /private/var/folders/n1/c6p1r6x10vz3wx7qpzrs8l780000gn/T/.tmpEwzmwW/release-plz/crates/release_plz_core/src/next_ver.rs:255
```

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).