### PR TITLE
chore: remove gitlab from release-pr backend

### DIFF
--- a/crates/release_plz/src/args/release.rs
+++ b/crates/release_plz/src/args/release.rs
@@ -1,12 +1,15 @@
 use std::path::PathBuf;
 
 use anyhow::Context;
-use clap::builder::{NonEmptyStringValueParser, PathBufValueParser};
+use clap::{
+    builder::{NonEmptyStringValueParser, PathBufValueParser},
+    ValueEnum,
+};
 use git_cmd::Repo;
 use release_plz_core::{GitBackend, GitHub, GitLab, Gitea, ReleaseRequest, RepoUrl};
 use secrecy::SecretString;
 
-use super::{local_manifest, release_pr::GitBackendKind};
+use super::local_manifest;
 
 #[derive(clap::Parser, Debug)]
 pub struct Release {
@@ -45,8 +48,18 @@ pub struct Release {
     #[arg(long, value_parser = NonEmptyStringValueParser::new())]
     pub git_token: Option<String>,
     /// Kind of git backend
-    #[arg(long, value_enum, default_value_t = GitBackendKind::Github)]
-    backend: GitBackendKind,
+    #[arg(long, value_enum, default_value_t = ReleaseGitBackendKind::Github)]
+    backend: ReleaseGitBackendKind,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReleaseGitBackendKind {
+    #[value(name = "github")]
+    Github,
+    #[value(name = "gitea")]
+    Gitea,
+    #[value(name = "gitlab")]
+    Gitlab,
 }
 
 impl TryFrom<Release> for ReleaseRequest {
@@ -62,11 +75,13 @@ impl TryFrom<Release> for ReleaseRequest {
             let repo_url = r.repo_url()?;
             let release = release_plz_core::GitRelease {
                 backend: match r.backend {
-                    GitBackendKind::Gitea => GitBackend::Gitea(Gitea::new(repo_url, git_token)?),
-                    GitBackendKind::Github => {
+                    ReleaseGitBackendKind::Gitea => {
+                        GitBackend::Gitea(Gitea::new(repo_url, git_token)?)
+                    }
+                    ReleaseGitBackendKind::Github => {
                         GitBackend::Github(GitHub::new(repo_url.owner, repo_url.name, git_token))
                     }
-                    GitBackendKind::Gitlab => {
+                    ReleaseGitBackendKind::Gitlab => {
                         GitBackend::Gitlab(GitLab::new(repo_url.owner, repo_url.name, git_token))
                     }
                 },

--- a/crates/release_plz/src/args/release_pr.rs
+++ b/crates/release_plz/src/args/release_pr.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use anyhow::Context;
 use clap::builder::NonEmptyStringValueParser;
 use clap::ValueEnum;
-use release_plz_core::{GitBackend, GitHub, GitLab, Gitea};
+use release_plz_core::{GitBackend, GitHub, Gitea};
 use secrecy::SecretString;
 
 use super::update::Update;
@@ -26,8 +26,6 @@ pub enum GitBackendKind {
     Github,
     #[value(name = "gitea")]
     Gitea,
-    #[value(name = "gitlab")]
-    Gitlab,
 }
 
 impl ReleasePr {
@@ -44,7 +42,6 @@ impl ReleasePr {
                 GitBackend::Github(GitHub::new(repo.owner, repo.name, token))
             }
             GitBackendKind::Gitea => GitBackend::Gitea(Gitea::new(repo, token)?),
-            GitBackendKind::Gitlab => GitBackend::Gitlab(GitLab::new(repo.owner, repo.name, token)),
         })
     }
 }

--- a/crates/release_plz_core/src/backend.rs
+++ b/crates/release_plz_core/src/backend.rs
@@ -169,7 +169,9 @@ impl GitClient {
         match self.backend {
             BackendType::Github => "per_page",
             BackendType::Gitea => "limit",
-            BackendType::Gitlab => unimplemented!("Gitlab support for `release-plz release-pr is not implemented yet"),
+            BackendType::Gitlab => {
+                unimplemented!("Gitlab support for `release-plz release-pr is not implemented yet")
+            }
         }
     }
 

--- a/crates/release_plz_core/src/backend.rs
+++ b/crates/release_plz_core/src/backend.rs
@@ -169,7 +169,7 @@ impl GitClient {
         match self.backend {
             BackendType::Github => "per_page",
             BackendType::Gitea => "limit",
-            BackendType::Gitlab => "per_page",
+            BackendType::Gitlab => unimplemented!("Gitlab support for `release-plz release-pr is not implemented yet"),
         }
     }
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
-->
It's not supported yet. We don't want to show it in the help menu.
