### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2728,7 +2728,7 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "release-plz"
-version = "0.2.56"
+version = "0.2.57"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2751,7 +2751,7 @@ dependencies = [
 
 [[package]]
 name = "release_plz_core"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "cargo",

--- a/crates/release_plz/CHANGELOG.md
+++ b/crates/release_plz/CHANGELOG.md
@@ -12,9 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(release)* add GitLab support (#591).
   `release-plz release-pr` GitLab support is still missing.
 
-### Other
-- remove gitlab from release-pr backend (#612)
-
 ## [0.2.56](https://github.com/MarcoIeni/release-plz/compare/release-plz-v0.2.55...release-plz-v0.2.56) - 2023-03-17
 
 ### Fixed

--- a/crates/release_plz/CHANGELOG.md
+++ b/crates/release_plz/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.57](https://github.com/MarcoIeni/release-plz/compare/release-plz-v0.2.56...release-plz-v0.2.57) - 2023-03-19
 
 ### Added
-- *(release)* add GitLab support (#591)
+- *(release)* add GitLab support (#591).
+  `release-plz release-pr` GitLab support is still missing.
 
 ### Other
 - remove gitlab from release-pr backend (#612)

--- a/crates/release_plz/CHANGELOG.md
+++ b/crates/release_plz/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.57](https://github.com/MarcoIeni/release-plz/compare/release-plz-v0.2.56...release-plz-v0.2.57) - 2023-03-19
+
+### Added
+- *(release)* add GitLab support (#591)
+
+### Other
+- remove gitlab from release-pr backend (#612)
+
 ## [0.2.56](https://github.com/MarcoIeni/release-plz/compare/release-plz-v0.2.55...release-plz-v0.2.56) - 2023-03-17
 
 ### Fixed

--- a/crates/release_plz/Cargo.toml
+++ b/crates/release_plz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release-plz"
-version = "0.2.56"
+version = "0.2.57"
 edition = "2021"
 description = "Update version and changelog based on semantic versioning and conventional commits"
 repository = "https://github.com/MarcoIeni/release-plz"
@@ -13,7 +13,7 @@ categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 git_cmd = { path = "../git_cmd", version = "0.3.0" }
-release_plz_core = { path = "../release_plz_core", version = "0.5.6" }
+release_plz_core = { path = "../release_plz_core", version = "0.5.7" }
 
 anyhow.workspace = true
 chrono = { workspace = true, features = ["clock"] }

--- a/crates/release_plz_core/CHANGELOG.md
+++ b/crates/release_plz_core/CHANGELOG.md
@@ -12,10 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(release)* add GitLab support (#591).
   `release-plz release-pr` GitLab support is still missing.
 
-### Other
-- gitea refactor (#613)
-- remove gitlab from release-pr backend (#612)
-
 ## [0.5.6](https://github.com/MarcoIeni/release-plz/compare/release_plz_core-v0.5.5...release_plz_core-v0.5.6) - 2023-03-17
 
 ### Added

--- a/crates/release_plz_core/CHANGELOG.md
+++ b/crates/release_plz_core/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.7](https://github.com/MarcoIeni/release-plz/compare/release_plz_core-v0.5.6...release_plz_core-v0.5.7) - 2023-03-19
+
+### Added
+- *(release)* add GitLab support (#591)
+
+### Other
+- gitea refactor (#613)
+- remove gitlab from release-pr backend (#612)
+
 ## [0.5.6](https://github.com/MarcoIeni/release-plz/compare/release_plz_core-v0.5.5...release_plz_core-v0.5.6) - 2023-03-17
 
 ### Added

--- a/crates/release_plz_core/CHANGELOG.md
+++ b/crates/release_plz_core/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.7](https://github.com/MarcoIeni/release-plz/compare/release_plz_core-v0.5.6...release_plz_core-v0.5.7) - 2023-03-19
 
 ### Added
-- *(release)* add GitLab support (#591)
+- *(release)* add GitLab support (#591).
+  `release-plz release-pr` GitLab support is still missing.
 
 ### Other
 - gitea refactor (#613)

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release_plz_core"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 description = "Update version and changelog based on semantic versioning and conventional commits"
 repository = "https://github.com/MarcoIeni/release-plz/tree/main/crates/release_plz_core"


### PR DESCRIPTION
## 🤖 New release
* `release-plz`: 0.2.56 -> 0.2.57
* `release_plz_core`: 0.5.6 -> 0.5.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `release-plz`
<blockquote>

## [0.2.57](https://github.com/MarcoIeni/release-plz/compare/release-plz-v0.2.56...release-plz-v0.2.57) - 2023-03-19

### Added
- *(release)* add GitLab support (#591)

### Other
- remove gitlab from release-pr backend (#612)
</blockquote>

## `release_plz_core`
<blockquote>

## [0.5.7](https://github.com/MarcoIeni/release-plz/compare/release_plz_core-v0.5.6...release_plz_core-v0.5.7) - 2023-03-19

### Added
- *(release)* add GitLab support (#591)

### Other
- gitea refactor (#613)
- remove gitlab from release-pr backend (#612)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).