### PR TITLE
fix: use default origin for repository url

### DIFF
--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -249,8 +249,10 @@ impl Repo {
         self.git(&["tag", name])
     }
 
-    pub fn origin_url(&self) -> anyhow::Result<String> {
-        self.git(&["config", "--get", "remote.origin.url"])
+    /// Url of the remote when the [`Repo`] was created.
+    pub fn original_remote_url(&self) -> anyhow::Result<String> {
+        let param = format!("remote.{}.url", self.original_remote);
+        self.git(&["config", "--get", &param])
     }
 
     pub fn tag_exists(&self, tag: &str) -> anyhow::Result<bool> {

--- a/crates/release_plz_core/src/repo_url.rs
+++ b/crates/release_plz_core/src/repo_url.rs
@@ -34,7 +34,9 @@ impl RepoUrl {
     }
 
     pub fn from_repo(repo: &Repo) -> Result<Self, anyhow::Error> {
-        let url = repo.origin_url().context("cannot determine origin url")?;
+        let url = repo
+            .original_remote_url()
+            .context("cannot determine origin url")?;
         RepoUrl::new(&url)
     }
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
-->
