### PR TITLE
fix: read opened PRs with empty body

### DIFF
--- a/crates/release_plz_core/src/backend.rs
+++ b/crates/release_plz_core/src/backend.rs
@@ -79,7 +79,7 @@ pub struct GitPr {
     pub html_url: Url,
     pub head: Commit,
     pub title: String,
-    pub body: String,
+    pub body: Option<String>,
 }
 
 impl GitPr {

--- a/crates/release_plz_core/src/release_pr.rs
+++ b/crates/release_plz_core/src/release_pr.rs
@@ -145,7 +145,7 @@ async fn update_pr(
         if opened_pr.title != new_pr.title {
             pr_edit = pr_edit.with_title(new_pr.title.clone());
         }
-        if opened_pr.body != new_pr.body {
+        if opened_pr.body.as_ref() != Some(&new_pr.body) {
             pr_edit = pr_edit.with_body(new_pr.body.clone());
         }
         pr_edit


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
