### PR TITLE
chore(mergify): don't update dependabot PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,13 +1,14 @@
 pull_request_rules:
   - name: Automatic merge for Dependabot pull requests
     conditions:
-      - author~=^dependabot(|-preview)\[bot\]$
+      - author=dependabot[bot]
     actions:
       merge:
         method: squash
   - name: Automatic update to the main branch for pull requests
     conditions:
       - -conflict # skip PRs with conflicts
-      - -draft # filter-out GH draft PRs
+      - -draft # skip GH draft PRs
+      - -author=dependabot[bot] # skip dependabot PRs
     actions:
       update:


### PR DESCRIPTION
This change has been made by @MarcoIeni from Mergify config editor.