### PR TITLE
fix: read full commit message

### DIFF
--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -242,7 +242,7 @@ impl Repo {
     }
 
     pub fn current_commit_message(&self) -> anyhow::Result<String> {
-        self.git(&["log", "-1", "--pretty=format:%s"])
+        self.git(&["log", "-1", "--pretty=format:%B"])
     }
 
     pub fn tag(&self, name: &str) -> anyhow::Result<String> {
@@ -347,10 +347,15 @@ mod tests {
         let repository_dir = tempdir().unwrap();
         let repo = Repo::init(&repository_dir);
         let file1 = repository_dir.as_ref().join("file1.txt");
-        let commit_message = "file1 message";
+
+        let header = "feat: file1";
+        let body = "message";
+        let footer = "footer: shoe";
+        let commit_message = format!("{}\n\n{}\n\n{}", header, body, footer);
+
         {
             fs::write(file1, b"Hello, file1!").unwrap();
-            repo.add_all_and_commit(commit_message).unwrap();
+            repo.add_all_and_commit(&commit_message).unwrap();
         }
         assert_eq!(repo.current_commit_message().unwrap(), commit_message);
     }


### PR DESCRIPTION
By changing the formatting the whole raw commit message is returned by `git log`.This way when determining the next version in `NextVersionFromDiff` (without semverchecK), commits with `Breaking Version` footers now also lead to a major version bump.

This fixes #687 .

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
