### PR TITLE
fix: don't return early when publishing crates

### DIFF
--- a/crates/release_plz_core/src/release.rs
+++ b/crates/release_plz_core/src/release.rs
@@ -244,7 +244,7 @@ pub async fn release(input: &ReleaseRequest) -> anyhow::Result<()> {
         for mut index in registry_indexes {
             if is_published(&mut index, package)? {
                 info!("{} {}: already published", package.name, package.version);
-                return Ok(());
+                continue;
             }
             release_package(&mut index, package, input, git_tag.clone()).await?;
         }


### PR DESCRIPTION
The loop over all release artefacts should not return when it finds a crate that is already published but instead continue to evaluate all other to-be-released artefacts.
