### PR TITLE
fix: ignore Cargo.lock dev dependencies changes

### DIFF
--- a/crates/release_plz_core/src/lock_compare.rs
+++ b/crates/release_plz_core/src/lock_compare.rs
@@ -48,15 +48,17 @@ fn are_dependencies_of_lockfiles_updated(
     registry_lock: &Lockfile,
     local_lock: &PackagesByName,
 ) -> bool {
-    for local_package in &registry_lock.packages {
-        if let Some(registry_packages) = local_lock.get(&local_package.name) {
-            let is_same_version = registry_packages
+    // We iterate over registry packages, because the local package can have more packages.
+    // In particular, the local package contains the dependencies of the dev dependencies.
+    for registry_package in &registry_lock.packages {
+        if let Some(local_packages) = local_lock.get(&registry_package.name) {
+            let is_same_version = local_packages
                 .iter()
-                .any(|p| p.version == local_package.version);
+                .any(|p| p.version == registry_package.version);
             if !is_same_version {
                 debug!(
                     "Version of package {} changed to version {:?}",
-                    local_package.name, local_package.version
+                    registry_package.name, registry_package.version
                 );
                 return true;
             }

--- a/crates/release_plz_core/src/lock_compare.rs
+++ b/crates/release_plz_core/src/lock_compare.rs
@@ -29,10 +29,10 @@ fn are_dependencies_updated(local_lock: &Path, registry_lock: &Path) -> anyhow::
             registry_lock
         )
     })?;
-    let registry_lock_packages = PackagesByName::new(&registry_lock.packages);
+    let local_lock_packages = PackagesByName::new(&local_lock.packages);
     Ok(are_dependencies_of_lockfiles_updated(
-        &local_lock,
-        &registry_lock_packages,
+        &registry_lock,
+        &local_lock_packages,
     ))
 }
 
@@ -45,11 +45,11 @@ fn read_lockfile(path: &Path) -> anyhow::Result<Lockfile> {
 }
 
 fn are_dependencies_of_lockfiles_updated(
-    local_lock: &Lockfile,
-    registry_lock: &PackagesByName,
+    registry_lock: &Lockfile,
+    local_lock: &PackagesByName,
 ) -> bool {
-    for local_package in &local_lock.packages {
-        if let Some(registry_packages) = registry_lock.get(&local_package.name) {
+    for local_package in &registry_lock.packages {
+        if let Some(registry_packages) = local_lock.get(&local_package.name) {
             let is_same_version = registry_packages
                 .iter()
                 .any(|p| p.version == local_package.version);

--- a/crates/release_plz_core/src/lock_compare.rs
+++ b/crates/release_plz_core/src/lock_compare.rs
@@ -48,8 +48,12 @@ fn are_dependencies_of_lockfiles_updated(
     registry_lock: &Lockfile,
     local_lock: &PackagesByName,
 ) -> bool {
-    // We iterate over registry packages, because the local package can have more packages.
+    // We iterate over registry packages, because the Cargo.lock of the
+    // local package can have more packages.
     // In particular, the local package contains the dependencies of the dev dependencies.
+    // If we iterate over local packages, this function will return true if
+    // the dev dependencies contain a version of a package different from the one
+    // used in the normal dependencies.
     for registry_package in &registry_lock.packages {
         if let Some(local_packages) = local_lock.get(&registry_package.name) {
             let is_same_version = local_packages


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
