### PR TITLE
fix: revert website breaking changes

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -12,7 +12,7 @@
                 "@docusaurus/preset-classic": "2.4.1",
                 "@easyops-cn/docusaurus-search-local": "^0.35.0",
                 "@mdx-js/react": "^2.3.0",
-                "clsx": "^2.0.0",
+                "clsx": "^1.2.1",
                 "prettier": "^3.0.0",
                 "prism-react-renderer": "^2.0.6",
                 "react": "^17.0.2",
@@ -2545,14 +2545,6 @@
                 "react": "^16.13.1 || ^17.0.0"
             }
         },
-        "node_modules/@docusaurus/theme-classic/node_modules/clsx": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/@docusaurus/theme-classic/node_modules/prism-react-renderer": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
@@ -2591,14 +2583,6 @@
                 "react-dom": "^16.8.4 || ^17.0.0"
             }
         },
-        "node_modules/@docusaurus/theme-common/node_modules/clsx": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/@docusaurus/theme-common/node_modules/prism-react-renderer": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
@@ -2635,14 +2619,6 @@
             "peerDependencies": {
                 "react": "^16.8.4 || ^17.0.0",
                 "react-dom": "^16.8.4 || ^17.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-search-algolia/node_modules/clsx": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/@docusaurus/theme-translations": {
@@ -2782,14 +2758,6 @@
                 "@docusaurus/theme-common": "^2.0.0-rc.1",
                 "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
                 "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
-            }
-        },
-        "node_modules/@easyops-cn/docusaurus-search-local/node_modules/clsx": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/@hapi/hoek": {
@@ -5046,9 +5014,9 @@
             }
         },
         "node_modules/clsx": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.0.0.tgz",
-            "integrity": "sha512-rQ1+kcj+ttHG0MKVGBUXwayCCF1oh39BF5COIpRzuCEv8Mwjv0XucrI2ExNTOn9IlLifGClWQcU9BrZORvtw6Q==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
             "engines": {
                 "node": ">=6"
             }
@@ -9968,14 +9936,6 @@
             },
             "peerDependencies": {
                 "react": ">=16.0.0"
-            }
-        },
-        "node_modules/prism-react-renderer/node_modules/clsx": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-            "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/prismjs": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,7 +11,7 @@
                 "@docusaurus/core": "2.4.1",
                 "@docusaurus/preset-classic": "2.4.1",
                 "@easyops-cn/docusaurus-search-local": "^0.35.0",
-                "@mdx-js/react": "^2.3.0",
+                "@mdx-js/react": "^1.6.22",
                 "clsx": "^1.2.1",
                 "prettier": "^3.0.0",
                 "prism-react-renderer": "^1.3.5",
@@ -2533,18 +2533,6 @@
                 "react-dom": "^16.8.4 || ^17.0.0"
             }
         },
-        "node_modules/@docusaurus/theme-classic/node_modules/@mdx-js/react": {
-            "version": "1.6.22",
-            "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
-            "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/unified"
-            },
-            "peerDependencies": {
-                "react": "^16.13.1 || ^17.0.0"
-            }
-        },
         "node_modules/@docusaurus/theme-common": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.1.tgz",
@@ -2995,19 +2983,15 @@
             }
         },
         "node_modules/@mdx-js/react": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.3.0.tgz",
-            "integrity": "sha512-zQH//gdOmuu7nt2oJR29vFhDv88oGPmVw6BggmrHeMI+xgEkp1B2dX9/bMBSYtK0dyLX/aOmesKS09g222K1/g==",
-            "dependencies": {
-                "@types/mdx": "^2.0.0",
-                "@types/react": ">=16"
-            },
+            "version": "1.6.22",
+            "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
+            "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             },
             "peerDependencies": {
-                "react": ">=16"
+                "react": "^16.13.1 || ^17.0.0"
             }
         },
         "node_modules/@mdx-js/util": {
@@ -3737,11 +3721,6 @@
             "dependencies": {
                 "@types/unist": "^2"
             }
-        },
-        "node_modules/@types/mdx": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.5.tgz",
-            "integrity": "sha512-76CqzuD6Q7LC+AtbPqrvD9AqsN0k8bsYo2bM2J8pmNldP1aIPAbzUQ7QbobyXL4eLr1wK5x8FZFe8eF/ubRuBg=="
         },
         "node_modules/@types/mime": {
             "version": "1.3.2",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14,7 +14,7 @@
                 "@mdx-js/react": "^2.3.0",
                 "clsx": "^1.2.1",
                 "prettier": "^3.0.0",
-                "prism-react-renderer": "^2.0.6",
+                "prism-react-renderer": "^1.3.5",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2"
             },
@@ -2545,14 +2545,6 @@
                 "react": "^16.13.1 || ^17.0.0"
             }
         },
-        "node_modules/@docusaurus/theme-classic/node_modules/prism-react-renderer": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-            "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
-            "peerDependencies": {
-                "react": ">=0.14.9"
-            }
-        },
         "node_modules/@docusaurus/theme-common": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.1.tgz",
@@ -2581,14 +2573,6 @@
             "peerDependencies": {
                 "react": "^16.8.4 || ^17.0.0",
                 "react-dom": "^16.8.4 || ^17.0.0"
-            }
-        },
-        "node_modules/@docusaurus/theme-common/node_modules/prism-react-renderer": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
-            "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
-            "peerDependencies": {
-                "react": ">=0.14.9"
             }
         },
         "node_modules/@docusaurus/theme-search-algolia": {
@@ -3778,11 +3762,6 @@
             "version": "5.0.3",
             "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
             "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw=="
-        },
-        "node_modules/@types/prismjs": {
-            "version": "1.26.0",
-            "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
-            "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ=="
         },
         "node_modules/@types/prop-types": {
             "version": "15.7.5",
@@ -9927,15 +9906,11 @@
             }
         },
         "node_modules/prism-react-renderer": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.0.6.tgz",
-            "integrity": "sha512-ERzmAI5UvrcTw5ivfEG20/dYClAsC84eSED5p9X3oKpm0xPV4A5clFK1mp7lPIdKmbLnQYsPTGiOI7WS6gWigw==",
-            "dependencies": {
-                "@types/prismjs": "^1.26.0",
-                "clsx": "^1.2.1"
-            },
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.3.5.tgz",
+            "integrity": "sha512-IJ+MSwBWKG+SM3b2SUfdrhC+gu01QkV2KmRQgREThBfSQRoufqRfxfHUxpG1WcaFjP+kojcFyO9Qqtpgt3qLCg==",
             "peerDependencies": {
-                "react": ">=16.0.0"
+                "react": ">=0.14.9"
             }
         },
         "node_modules/prismjs": {

--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,7 @@
         "@docusaurus/core": "2.4.1",
         "@docusaurus/preset-classic": "2.4.1",
         "@easyops-cn/docusaurus-search-local": "^0.35.0",
-        "@mdx-js/react": "^2.3.0",
+        "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "prettier": "^3.0.0",
         "prism-react-renderer": "^1.3.5",

--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,7 @@
         "@mdx-js/react": "^2.3.0",
         "clsx": "^1.2.1",
         "prettier": "^3.0.0",
-        "prism-react-renderer": "^2.0.6",
+        "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
     },

--- a/website/package.json
+++ b/website/package.json
@@ -21,7 +21,7 @@
         "@docusaurus/preset-classic": "2.4.1",
         "@easyops-cn/docusaurus-search-local": "^0.35.0",
         "@mdx-js/react": "^2.3.0",
-        "clsx": "^2.0.0",
+        "clsx": "^1.2.1",
         "prettier": "^3.0.0",
         "prism-react-renderer": "^2.0.6",
         "react": "^17.0.2",


### PR DESCRIPTION
- Revert "build(deps): bump clsx from 1.2.1 to 2.0.0 in /website (#878)"
- Revert "build(deps): bump prism-react-renderer from 1.3.5 to 2.0.6 in /website (#879)"
- Revert "build(deps): bump @mdx-js/react from 1.6.22 to 2.3.0 in /website (#893)"

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
