### PR TITLE
feat: pass commit ids to git-cliff

### DIFF
--- a/crates/release_plz_core/src/diff.rs
+++ b/crates/release_plz_core/src/diff.rs
@@ -1,10 +1,12 @@
+use git_cliff_core::commit::Commit;
+
 use crate::semver_check::SemverCheck;
 
 /// Difference between local and registry package (i.e. the last released version)
 #[derive(Debug)]
-pub(crate) struct Diff {
+pub(crate) struct Diff<'a> {
     /// List of commits from last released version to last local changes.
-    pub commits: Vec<String>,
+    pub commits: Vec<Commit<'a>>,
     /// Whether the package name exists in the registry or not.
     pub registry_package_exists: bool,
     /// Whether the current local version is published to the registry.
@@ -14,7 +16,7 @@ pub(crate) struct Diff {
     pub semver_check: SemverCheck,
 }
 
-impl Diff {
+impl<'a> Diff<'a> {
     pub fn new(registry_package_exists: bool) -> Self {
         Self {
             commits: vec![],
@@ -35,7 +37,8 @@ impl Diff {
     pub fn set_semver_check(&mut self, semver_check: SemverCheck) {
         self.semver_check = semver_check
     }
-    pub fn add_commits(&mut self, commits: &[String]) {
+
+    pub fn add_commits(&mut self, commits: &[Commit<'a>]) {
         for c in commits {
             if !self.commits.contains(c) {
                 self.commits.push(c.clone());

--- a/crates/release_plz_core/src/version.rs
+++ b/crates/release_plz_core/src/version.rs
@@ -17,14 +17,16 @@ impl NextVersionFromDiff for Version {
             let increment = VersionIncrement::breaking(self);
             increment.bump(self)
         } else {
-            self.next(&diff.commits)
+            self.next(diff.commits.iter().map(|c| &c.message))
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::semver_check::SemverCheck;
+    use git_cliff_core::commit::Commit;
+
+    use crate::{semver_check::SemverCheck, NO_COMMIT_ID};
 
     use super::*;
 
@@ -40,7 +42,10 @@ mod tests {
     fn next_version_of_existing_package_is_updated() {
         let diff = Diff {
             registry_package_exists: true,
-            commits: vec!["my change".to_string()],
+            commits: vec![Commit::new(
+                NO_COMMIT_ID.to_string(),
+                "my change".to_string(),
+            )],
             is_version_published: true,
             semver_check: SemverCheck::Skipped,
         };


### PR DESCRIPTION
Resolves #954 

This change passes the commit IDs to `git-cliff` when the changelog is generated, allowing users to use commit IDs in their changelog formats.

When using a commit message without an actual commit, I changed the placeholder value to "N/A", indicating there is no corresponding commit ID available. Happy to discuss this further if you'd like to handle this case differently.