### PR TITLE
docs: add release subcommand usage on Gitlab

### DIFF
--- a/website/docs/usage/release.md
+++ b/website/docs/usage/release.md
@@ -34,6 +34,7 @@ To learn more, run `release-plz release --help`.
 The default token in CI does not have permissions to create tags, so you will need to
 a custom [access token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html).
 The permissions you need are:
+
 - `api` (to create a release)
 - `write_repository` (to create tag)
 

--- a/website/docs/usage/release.md
+++ b/website/docs/usage/release.md
@@ -40,4 +40,4 @@ The permissions you need are:
 
 Then you can run `release-plz release` in Gitlab CI with the following arguments:
 
-`release-plz release --backend gitlab --git-token <gitlab application token> --repo-url <repository URL>`
+`release-plz release --backend gitlab --git-token <gitlab application token>`

--- a/website/docs/usage/release.md
+++ b/website/docs/usage/release.md
@@ -26,3 +26,17 @@ or you merge a pull request opened with `release-plz release-pr`.
 If all packages are already published, the `release-plz release` command does nothing.
 
 To learn more, run `release-plz release --help`.
+
+## Gitlab
+
+`releases-plz` also supports creating releases on Gitlab with the `--backend gitlab` option.
+
+The default token in CI does not have permissions to create tags, so you will need to
+a custom [access token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html).
+The permissions you need are:
+- `api` (to create a release)
+- `write_repository` (to create tag)
+
+Then you can run `release-plz release` in Gitlab CI with the following arguments:
+
+`release-plz release --backend gitlab --git-token <gitlab application token> --repo-url <repository URL>`


### PR DESCRIPTION
Add release subcommand usage on Gitlab, detailing the required arguments and scopes required for Gitlab access token.

Closes #847.
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
