### PR TITLE
docs: update git-cliff links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Release-plz helps you release your Rust packages by automating:
 
-- CHANGELOG generation (with [git-cliff](https://github.com/orhun/git-cliff)).
+- CHANGELOG generation (with [git-cliff](https://git-cliff.org)).
 - Creation of GitHub/Gitea releases.
 - Publishing to a cargo registry (`crates.io` by default).
 - Version bumps in `Cargo.toml`.

--- a/website/docs/changelog-format.md
+++ b/website/docs/changelog-format.md
@@ -1,12 +1,14 @@
 # Changelog format
 
-Release-plz generates the changelog by using [git-cliff](https://github.com/orhun/git-cliff).
+Release-plz generates the changelog by using [git-cliff](https://git-cliff.org).
 By default, release-plz uses the
 [keep a changelog](https://keepachangelog.com/en/1.1.0/) format.
 
 You can customize the changelog format, by providing a git-cliff configuration
 file with the `--changelog-config` argument, or with the
 [`changelog_config`](config.md#the-changelog_config-field) of the configuration file.
+
+See the [git-cliff documentation](https://git-cliff.org/docs/configuration) to see how to customize the changelog format.
 
 ## How should I write my commits?
 

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -284,4 +284,4 @@ Overrides the [`workspace.publish_no_verify`](#the-publish_no_verify-field) fiel
 By default, release-plz runs [cargo-semver-checks] if the package is a library.
 
 [cargo-semver-checks]: https://github.com/obi1kenobi/cargo-semver-checks
-[git-cliff]: https://github.com/orhun/git-cliff
+[git-cliff]: https://git-cliff.org

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -38,4 +38,4 @@ files of the crate or one of its dependencies.
 
 By default, it will be listed under the section `### Other`.
 Remember you can customize the changelog format by providing a
-[git-cliff](https://github.com/orhun/git-cliff) config file.
+[git-cliff](https://git-cliff.org) config file.

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -32,7 +32,7 @@ Here's an example of a release Pull Request created on the release-plz repositor
 ## Release-plz features
 
 - Version update based on [conventional commits](https://www.conventionalcommits.org/).
-- Changelog update with [git-cliff](https://github.com/orhun/git-cliff),
+- Changelog update with [git-cliff](https://git-cliff.org),
   using the [keep a changelog](https://keepachangelog.com/en/1.1.0/) format by default.
 - API breaking changes detection with [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks).
 - Cargo workspaces support.

--- a/website/src/components/HomepageFeatures/index.js
+++ b/website/src/components/HomepageFeatures/index.js
@@ -8,7 +8,7 @@ const FeatureList = [
     description: (
       <>
         Release-plz updates your changelogs with{" "}
-        <a href="https://github.com/orhun/git-cliff">git-cliff</a> using{" "}
+        <a href="https://git-cliff.org">git-cliff</a> using{" "}
         <a href="https://keepachangelog.com/en/1.0.0/">Keep a changelog</a> format by default.
       </>
     ),


### PR DESCRIPTION
This PR updates the `git-cliff` links to use the website instead of the repo when applicable.
