### PR TITLE
Revert "chore(ci): publish release after binary upload (#990)"

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,5 +70,3 @@ jobs:
           tar: all
           zip: windows
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish release
-        run: gh release edit ${{ github.event.release.name }} --draft=false

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,5 @@
 [workspace]
 git_release_enable = false
-git_release_draft = true
 
 [[package]] # the double square brackets define a TOML table array
 name = "release-plz" # name of the package to configure


### PR DESCRIPTION
This reverts commit 8398a329aa70a8495bc68b59eeae49c23defa66e.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->

You can't trigger github actions on draft releases.