### PR TITLE
fix: use registry argument on publish

### DIFF
--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -452,6 +452,10 @@ fn run_cargo_publish(
     args.push("always");
     args.push("--manifest-path");
     args.push(package.manifest_path.as_ref());
+    if let Some(registry) = &input.registry {
+        args.push("--registry");
+        args.push(registry);
+    }
     if let Some(token) = &input.token {
         args.push("--token");
         args.push(token.expose_secret());


### PR DESCRIPTION
The `registry` argument was not being used when calling `cargo publish`, causing it to try to publish to `crates.io` even when a different registry was passed.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
