### PR TITLE
feat: support .release-plz.toml as a config file

### DIFF
--- a/crates/release_plz/src/args/mod.rs
+++ b/crates/release_plz/src/args/mod.rs
@@ -57,20 +57,52 @@ fn local_manifest(project_manifest: Option<&Path>) -> PathBuf {
 }
 
 fn parse_config(config_path: Option<&Path>) -> anyhow::Result<Config> {
-    let config_path: PathBuf = config_path
-        .map(|p| p.to_path_buf())
-        .unwrap_or("release-plz.toml".into());
-    match std::fs::read_to_string(&config_path) {
-        Ok(config) => {
-            info!("using release-plz config file {}", config_path.display());
-            toml::from_str(&config).with_context(|| format!("invalid config file {config_path:?}"))
+    let (config, path) = if let Some(config_path) = config_path {
+        match std::fs::read_to_string(config_path) {
+            Ok(config) => (config, config_path),
+            Err(e) => match e.kind() {
+                std::io::ErrorKind::NotFound => {
+                    anyhow::bail!("specified config does not exist at path {config_path:?}")
+                }
+                _ => anyhow::bail!("can't read {config_path:?}: {e:?}"),
+            },
         }
-        Err(e) => match e.kind() {
-            std::io::ErrorKind::NotFound => {
+    } else {
+        match first_file_contents([
+            Path::new("release-plz.toml"),
+            Path::new(".release-plz.toml"),
+        ])? {
+            Some((config, path)) => (config, path),
+            None => {
                 info!("release-plz config file not found, using default configuration");
-                Ok(Config::default())
+                return Ok(Config::default());
             }
-            _ => anyhow::bail!("can't read {config_path:?}: {e:?}"),
-        },
+        }
+    };
+
+    info!("using release-plz config file {}", path.display());
+    toml::from_str(&config).with_context(|| format!("invalid config file {config_path:?}"))
+}
+
+/// Returns the contents of the first file that exists.
+///
+/// If none of the files exist, returns `Ok(None)`.
+///
+/// # Errors
+///
+/// Errors if opening and reading one of files paths fails for reasons other that it doesn't exist.
+fn first_file_contents<'a>(
+    paths: impl IntoIterator<Item = &'a Path>,
+) -> anyhow::Result<Option<(String, &'a Path)>> {
+    let paths = paths.into_iter();
+
+    for path in paths {
+        match std::fs::read_to_string(path) {
+            Ok(config) => return Ok(Some((config, path))),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
     }
+
+    Ok(None)
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

Keeping configuration in dotfiles is often desirable. This PR supports a root `.release-plz.toml` config file if `release-plz.toml` is not found.

If you'd rather this be considered supported already through the `config` CLI arg then I would understand, but would also suggest adding support for that arg to the GH action.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
