### PR TITLE
docs: add documentation for dot config

### DIFF
--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -6,7 +6,7 @@ with the `release-plz.toml` file.
 This configuration file is optional — release-plz is designed to work out of the box,
 with decent defaults.
 
-Put the `release-plz.toml` file in the same directory of your root `Cargo.toml`.
+Put your `release-plz.toml` (or `.release-plz.toml`) file in the same directory of your root `Cargo.toml`.
 
 ## Example
 


### PR DESCRIPTION
Follow up to #1057 where I forgot to add the website docs.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
