### PR TITLE
fix: resolve issue on Windows machines that use CRLF that would duplicate the header on each update

### DIFF
--- a/crates/release_plz_core/src/changelog_parser.rs
+++ b/crates/release_plz_core/src/changelog_parser.rs
@@ -10,12 +10,12 @@ use regex::Regex;
 ///   (in the ..anything.. case, `## ..anything..` is not included in the header)
 pub fn parse_header(changelog: &str) -> Option<String> {
     lazy_static::lazy_static! {
-        static ref FIRST_RE: Regex = Regex::new(r"(?s)^(# Changelog|# CHANGELOG|# changelog)(.*)(## Unreleased|## \[Unreleased\]|## unreleased|## \[unreleased\])").unwrap();
-
+        static ref FIRST_RE: Regex = Regex::new(r"(?s)^(# Changelog|# CHANGELOG|# changelog)(.*)(## Unreleased|## \[Unreleased\]|## unreleased|## \[unreleased\])(.*?)(\n)").unwrap();
         static ref SECOND_RE: Regex = Regex::new(r"(?s)^(# Changelog|# CHANGELOG|# changelog)(.*?)(\n## )").unwrap();
     }
+
     if let Some(captures) = FIRST_RE.captures(changelog) {
-        return Some(format!("{}\n", &captures[0]));
+        return Some(format!("{}", &captures[0]));
     }
 
     if let Some(captures) = SECOND_RE.captures(changelog) {
@@ -125,6 +125,13 @@ My custom changelog header
 ## [Unreleased]
 ";
         assert_eq!(header, expected_header);
+    }
+
+    #[test]
+    fn changelog_header_with_crlf_parsed_will_contain_crlf() {
+        let changelog = "# Changelog\r\n\r\nMy custom changelog header\r\n\r\n## [Unreleased]\r\n";
+        let header = parse_header(changelog).unwrap_or("".to_string());
+        assert_eq!(header, changelog);
     }
 
     #[test]

--- a/crates/release_plz_core/src/changelog_parser.rs
+++ b/crates/release_plz_core/src/changelog_parser.rs
@@ -15,7 +15,7 @@ pub fn parse_header(changelog: &str) -> Option<String> {
     }
 
     if let Some(captures) = FIRST_RE.captures(changelog) {
-        return Some(&captures[0].to_string());
+        return Some(captures[0].to_string());
     }
 
     if let Some(captures) = SECOND_RE.captures(changelog) {

--- a/crates/release_plz_core/src/changelog_parser.rs
+++ b/crates/release_plz_core/src/changelog_parser.rs
@@ -15,7 +15,7 @@ pub fn parse_header(changelog: &str) -> Option<String> {
     }
 
     if let Some(captures) = FIRST_RE.captures(changelog) {
-        return Some(format!("{}", &captures[0]));
+        return Some(&captures[0].to_string());
     }
 
     if let Some(captures) = SECOND_RE.captures(changelog) {


### PR DESCRIPTION
I ran into an issue on Windows where the header would be added (but not replaced\removed) on each update.
This is because the line `## [Unreleased]` would end with CRLF but the code would assume it was LF.
So when the `prepend` function in git-cliff would be called, the `replacen` function would not get a match.

Here is a screenshot of the generated file showing the characters:
![image](https://github.com/MarcoIeni/release-plz/assets/16911399/d8f2d3ff-268d-403d-a8d8-eddce0d2060b)

I added a test too!