### PR TITLE
feat: new generate-schema command to generate a JSON schema for the configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,22 @@ jobs:
       - name: Clippy check
         run: cargo clippy --all-targets --all-features --workspace -- -D warnings
 
+  schema:
+    name: Schema
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run release-plz generate-schema
+        run: cargo run --package release-plz --bin release-plz generate-schema
+      - name: Check schema
+        run: |
+          gitdiff=$(git status .schema/latest.json | grep "modified:")
+          test -z "$gitdiff" && (exit 0) || (exit 1)
+
   docs:
     name: Docs
     runs-on: ubuntu-22.04

--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -1,0 +1,311 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/MarcoIeni/release-plz/".schema/latest.json
+  "title": "Config",
+  "type": "object",
+  "properties": {
+    "package": {
+      "title": "Package",
+      "description": "Package-specific configuration. This overrides `workspace`. Not all settings of `workspace` can be overridden.",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/PackageSpecificConfigWithName"
+      }
+    },
+    "workspace": {
+      "title": "Workspace",
+      "description": "Global configuration. Applied to all packages by default.",
+      "default": {
+        "allow_dirty": null,
+        "changelog_config": null,
+        "changelog_update": null,
+        "dependencies_update": null,
+        "git_release_draft": null,
+        "git_release_enable": null,
+        "git_release_type": null,
+        "git_tag_enable": null,
+        "pr_draft": false,
+        "pr_labels": [],
+        "publish": null,
+        "publish_allow_dirty": null,
+        "publish_no_verify": null,
+        "repo_url": null,
+        "semver_check": null
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Workspace"
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "PackageSpecificConfigWithName": {
+      "description": "Config at the `[[package]]` level.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "changelog_include": {
+          "title": "Changelog Include",
+          "description": "List of package names. Include the changelogs of these packages in the changelog of the current package.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "changelog_path": {
+          "title": "Changelog Path",
+          "description": "Normally the changelog is placed in the same directory of the Cargo.toml file. The user can provide a custom path here. This changelog_path needs to be propagated to all the commands: `update`, `release-pr` and `release`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "changelog_update": {
+          "title": "Changelog Update",
+          "description": "Whether to create/update changelog or not. If unspecified, the changelog is updated.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "git_release_draft": {
+          "title": "Git Release Draft",
+          "description": "If true, will not auto-publish the release.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "git_release_enable": {
+          "title": "Git Release Enable",
+          "description": "Publish the GitHub/Gitea release for the created git tag. Enabled by default.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "git_release_type": {
+          "title": "Git Release Type",
+          "description": "Whether to mark the created release as not ready for production.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ReleaseType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "git_tag_enable": {
+          "title": "Git Tag Enable",
+          "description": "Publish the git tag for the new package version. Enabled by default.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "publish": {
+          "title": "Publish",
+          "description": "If `Some(false)`, don't run `cargo publish`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "publish_allow_dirty": {
+          "title": "Publish Allow Dirty",
+          "description": "If `Some(true)`, add the `--allow-dirty` flag to the `cargo publish` command.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "publish_no_verify": {
+          "title": "Publish No Verify",
+          "description": "If `Some(true)`, add the `--no-verify` flag to the `cargo publish` command.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "semver_check": {
+          "title": "Semver Check",
+          "description": "Controls when to run cargo-semver-checks. If unspecified, run cargo-semver-checks if the package is a library.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "ReleaseType": {
+      "oneOf": [
+        {
+          "title": "Prod",
+          "description": "Will mark the release as ready for production.",
+          "type": "string",
+          "enum": [
+            "prod"
+          ]
+        },
+        {
+          "title": "Pre",
+          "description": "Will mark the release as not ready for production. I.e. as pre-release.",
+          "type": "string",
+          "enum": [
+            "pre"
+          ]
+        },
+        {
+          "title": "Auto",
+          "description": "Will mark the release as not ready for production in case there is a semver pre-release in the tag e.g. v1.0.0-rc1. Otherwise, will mark the release as ready for production.",
+          "type": "string",
+          "enum": [
+            "auto"
+          ]
+        }
+      ]
+    },
+    "Workspace": {
+      "description": "Global configuration.",
+      "type": "object",
+      "properties": {
+        "allow_dirty": {
+          "title": "Allow Dirty",
+          "description": "- If `true`, allow dirty working directories to be updated. The uncommitted changes will be part of the update. - If `false` or [`Option::None`], the command will fail if the working directory is dirty.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "changelog_config": {
+          "title": "Changelog Config",
+          "description": "Path to the git cliff configuration file. Defaults to the `keep a changelog` configuration.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "changelog_update": {
+          "title": "Changelog Update",
+          "description": "Whether to create/update changelog or not. If unspecified, the changelog is updated.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dependencies_update": {
+          "title": "Dependencies Update",
+          "description": "- If `true`, update all the dependencies in the Cargo.lock file by running `cargo update`. - If `false` or [`Option::None`], only update the workspace packages by running `cargo update --workspace`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "git_release_draft": {
+          "title": "Git Release Draft",
+          "description": "If true, will not auto-publish the release.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "git_release_enable": {
+          "title": "Git Release Enable",
+          "description": "Publish the GitHub/Gitea release for the created git tag. Enabled by default.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "git_release_type": {
+          "title": "Git Release Type",
+          "description": "Whether to mark the created release as not ready for production.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ReleaseType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "git_tag_enable": {
+          "title": "Git Tag Enable",
+          "description": "Publish the git tag for the new package version. Enabled by default.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "pr_draft": {
+          "title": "PR Draft",
+          "description": "If `true`, the created release PR will be marked as a draft.",
+          "default": false,
+          "type": "boolean"
+        },
+        "pr_labels": {
+          "title": "PR Labels",
+          "description": "Labels to add to the release PR.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "publish": {
+          "title": "Publish",
+          "description": "If `Some(false)`, don't run `cargo publish`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "publish_allow_dirty": {
+          "title": "Publish Allow Dirty",
+          "description": "If `Some(true)`, add the `--allow-dirty` flag to the `cargo publish` command.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "publish_no_verify": {
+          "title": "Publish No Verify",
+          "description": "If `Some(true)`, add the `--no-verify` flag to the `cargo publish` command.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "repo_url": {
+          "title": "Repo URL",
+          "description": "GitHub/Gitea repository url where your project is hosted. It is used to generate the changelog release link. It defaults to the url of the default remote.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "uri"
+        },
+        "semver_check": {
+          "title": "Semver Check",
+          "description": "Controls when to run cargo-semver-checks. If unspecified, run cargo-semver-checks if the package is a library.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/MarcoIeni/release-plz/".schema/latest.json
+  "$id": "https://github.com/MarcoIeni/release-plz/.schema/latest.json",
   "title": "Config",
   "type": "object",
   "properties": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
+
+[[package]]
 name = "ecdsa"
 version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4165,6 +4171,7 @@ dependencies = [
  "git_cmd",
  "release_plz_core",
  "reqwest",
+ "schemars",
  "secrecy",
  "serde",
  "serde_json",
@@ -4429,6 +4436,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4517,6 +4549,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ regex = "1.10.2"
 reqwest = "0.11.22"
 reqwest-middleware = "0.2.3"
 reqwest-retry = "0.3.0"
+schemars = { version = "0.8.16", features = ["url"] }
 secrecy = "0.8.0"
 semver = "1.0.20"
 serde = "1.0.193"

--- a/crates/release_plz/Cargo.toml
+++ b/crates/release_plz/Cargo.toml
@@ -30,8 +30,10 @@ clap_complete.workspace = true
 dirs.workspace = true
 git-cliff-core.workspace = true
 reqwest.workspace = true
+schemars.workspace = true
 secrecy.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-log.workspace = true

--- a/crates/release_plz/src/args/mod.rs
+++ b/crates/release_plz/src/args/mod.rs
@@ -45,6 +45,8 @@ pub enum Command {
     GenerateCompletions(GenerateCompletions),
     /// Check if a newer version of release-plz is available.
     CheckUpdates,
+    /// Generate a JSON schema of the configuration (.toml)
+    GenerateSchema,
 }
 
 fn local_manifest(project_manifest: Option<&Path>) -> PathBuf {

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -1,14 +1,17 @@
 use release_plz_core::{ReleaseRequest, UpdateRequest};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::PathBuf};
 use url::Url;
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    /// # Workspace
     /// Global configuration. Applied to all packages by default.
     #[serde(default)]
     pub workspace: Workspace,
+    /// # Package
     /// Package-specific configuration. This overrides `workspace`.
     /// Not all settings of `workspace` can be overridden.
     #[serde(default)]
@@ -80,7 +83,7 @@ impl Config {
 }
 
 /// Global configuration.
-#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug, JsonSchema)]
 pub struct Workspace {
     /// Configuration for the `release-plz update` command.
     /// These options also affect the `release-plz release-pr` command.
@@ -95,9 +98,10 @@ pub struct Workspace {
     pub packages_defaults: PackageConfig,
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug, JsonSchema)]
 /// Configuration shared among various commands.
 pub struct CommonCmdConfig {
+    /// # Repo URL
     /// GitHub/Gitea repository url where your project is hosted.
     /// It is used to generate the changelog release link.
     /// It defaults to the url of the default remote.
@@ -106,13 +110,16 @@ pub struct CommonCmdConfig {
 
 /// Configuration for the `update` command.
 /// Generical for the whole workspace. Cannot be customized on a per-package basic.
-#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug, JsonSchema)]
 pub struct UpdateConfig {
+    /// # Dependencies Update
     /// - If `true`, update all the dependencies in the Cargo.lock file by running `cargo update`.
     /// - If `false` or [`Option::None`], only update the workspace packages by running `cargo update --workspace`.
     pub dependencies_update: Option<bool>,
+    /// # Changelog Config
     /// Path to the git cliff configuration file. Defaults to the `keep a changelog` configuration.
     pub changelog_config: Option<PathBuf>,
+    /// # Allow Dirty
     /// - If `true`, allow dirty working directories to be updated. The uncommitted changes will be part of the update.
     /// - If `false` or [`Option::None`], the command will fail if the working directory is dirty.
     pub allow_dirty: Option<bool>,
@@ -120,18 +127,20 @@ pub struct UpdateConfig {
 
 /// Configuration for the `release-pr` command.
 /// Generical for the whole workspace. Cannot be customized on a per-package basic.
-#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug, JsonSchema)]
 pub struct ReleasePrConfig {
+    /// # PR Draft
     /// If `true`, the created release PR will be marked as a draft.
     #[serde(default)]
     pub pr_draft: bool,
+    /// # PR Labels
     /// Labels to add to the release PR.
     #[serde(default)]
     pub pr_labels: Vec<String>,
 }
 
 /// Config at the `[[package]]` level.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, JsonSchema)]
 pub struct PackageSpecificConfig {
     /// Options for the `release-plz update` command (therefore `release-plz release-pr` too).
     #[serde(flatten)]
@@ -139,11 +148,13 @@ pub struct PackageSpecificConfig {
     /// Options for the `release-plz release` command.
     #[serde(flatten)]
     release: PackageReleaseConfig,
+    /// # Changelog Path
     /// Normally the changelog is placed in the same directory of the Cargo.toml file.
     /// The user can provide a custom path here.
     /// This changelog_path needs to be propagated to all the commands:
     /// `update`, `release-pr` and `release`.
     changelog_path: Option<PathBuf>,
+    /// # Changelog Include
     /// List of package names.
     /// Include the changelogs of these packages in the changelog of the current package.
     changelog_include: Option<Vec<String>>,
@@ -161,7 +172,7 @@ impl PackageSpecificConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, JsonSchema)]
 pub struct PackageSpecificConfigWithName {
     pub name: String,
     #[serde(flatten)]
@@ -203,7 +214,7 @@ impl From<PackageReleaseConfig> for release_plz_core::ReleaseConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone, JsonSchema)]
 pub struct PackageConfig {
     /// Options for the `release-plz update` command (therefore `release-plz release-pr` too).
     #[serde(flatten)]
@@ -234,11 +245,13 @@ impl From<PackageSpecificConfig> for release_plz_core::PackageUpdateConfig {
 
 /// Customization for the `release-plz update` command.
 /// These can be overridden on a per-package basic.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone, JsonSchema)]
 pub struct PackageUpdateConfig {
+    /// # Semver Check
     /// Controls when to run cargo-semver-checks.
     /// If unspecified, run cargo-semver-checks if the package is a library.
     pub semver_check: Option<bool>,
+    /// # Changelog Update
     /// Whether to create/update changelog or not.
     /// If unspecified, the changelog is updated.
     pub changelog_update: Option<bool>,
@@ -254,7 +267,7 @@ impl PackageUpdateConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone, JsonSchema)]
 pub struct PackageReleaseConfig {
     /// Configuration for the GitHub/Gitea/GitLab release.
     #[serde(flatten, default)]
@@ -276,13 +289,16 @@ impl PackageReleaseConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone, JsonSchema)]
 pub struct ReleaseConfig {
+    /// # Publish
     /// If `Some(false)`, don't run `cargo publish`.
     pub publish: Option<bool>,
+    /// # Publish Allow Dirty
     /// If `Some(true)`, add the `--allow-dirty` flag to the `cargo publish` command.
     #[serde(rename = "publish_allow_dirty")]
     pub allow_dirty: Option<bool>,
+    /// # Publish No Verify
     /// If `Some(true)`, add the `--no-verify` flag to the `cargo publish` command.
     #[serde(rename = "publish_no_verify")]
     pub no_verify: Option<bool>,
@@ -311,8 +327,9 @@ pub enum SemverCheck {
     No,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default, JsonSchema)]
 pub struct GitTagConfig {
+    /// # Git Tag Enable
     /// Publish the git tag for the new package version.
     /// Enabled by default.
     #[serde(rename = "git_tag_enable")]
@@ -327,15 +344,18 @@ impl GitTagConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default, JsonSchema)]
 pub struct GitReleaseConfig {
+    /// # Git Release Enable
     /// Publish the GitHub/Gitea release for the created git tag.
     /// Enabled by default.
     #[serde(rename = "git_release_enable")]
     enable: Option<bool>,
+    /// # Git Release Type
     /// Whether to mark the created release as not ready for production.
     #[serde(rename = "git_release_type")]
     pub release_type: Option<ReleaseType>,
+    /// # Git Release Draft
     /// If true, will not auto-publish the release.
     #[serde(rename = "git_release_draft")]
     pub draft: Option<bool>,
@@ -352,15 +372,18 @@ impl GitReleaseConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, Default, PartialEq, Eq, Debug, Clone, Copy, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ReleaseType {
+    /// # Prod
     /// Will mark the release as ready for production.
     #[default]
     Prod,
+    /// # Pre
     /// Will mark the release as not ready for production.
     /// I.e. as pre-release.
     Pre,
+    /// # Auto
     /// Will mark the release as not ready for production
     /// in case there is a semver pre-release in the tag e.g. v1.0.0-rc1.
     /// Otherwise, will mark the release as ready for production.

--- a/crates/release_plz/src/generate_schema.rs
+++ b/crates/release_plz/src/generate_schema.rs
@@ -2,7 +2,7 @@ use crate::config;
 use schemars::schema_for;
 use std::fs;
 
-/// Generate the Schema for the configuration file, meant to be used on SchemaStore for IDE
+/// Generate the Schema for the configuration file, meant to be used on `SchemaStore` for IDE
 /// completion
 pub fn generate_schema() {
     const SCHEMA_TOKEN: &str = r##"schema#","##;
@@ -19,5 +19,5 @@ pub fn generate_schema() {
         &format!("{}\n  {}{}{}\",", SCHEMA_TOKEN, ID, FOLDER, FILE),
     );
     fs::create_dir_all(FOLDER).unwrap();
-    fs::write(&format!("{}{}", FOLDER, FILE), json).unwrap();
+    fs::write(format!("{}{}", FOLDER, FILE), json).unwrap();
 }

--- a/crates/release_plz/src/generate_schema.rs
+++ b/crates/release_plz/src/generate_schema.rs
@@ -6,7 +6,7 @@ use std::fs;
 /// completion
 pub fn generate_schema() {
     const SCHEMA_TOKEN: &str = r##"schema#","##;
-    const ID: &str = r##""$id": "https://github.com/MarcoIeni/release-plz/""##;
+    const ID: &str = r##""$id": "https://github.com/MarcoIeni/release-plz/"##;
     const FOLDER: &str = ".schema/";
     const FILE: &str = "latest.json";
 
@@ -16,7 +16,7 @@ pub fn generate_schema() {
     // See here for update on resolution: https://github.com/GREsau/schemars/issues/229
     json = json.replace(
         SCHEMA_TOKEN,
-        &format!("{}\n  {}{}{}", SCHEMA_TOKEN, ID, FOLDER, FILE),
+        &format!("{}\n  {}{}{}\",", SCHEMA_TOKEN, ID, FOLDER, FILE),
     );
     fs::create_dir_all(FOLDER).unwrap();
     fs::write(&format!("{}{}", FOLDER, FILE), json).unwrap();

--- a/crates/release_plz/src/generate_schema.rs
+++ b/crates/release_plz/src/generate_schema.rs
@@ -1,0 +1,23 @@
+use crate::config;
+use schemars::schema_for;
+use std::fs;
+
+/// Generate the Schema for the configuration file, meant to be used on SchemaStore for IDE
+/// completion
+pub fn generate_schema() {
+    const SCHEMA_TOKEN: &str = r##"schema#","##;
+    const ID: &str = r##""$id": "https://github.com/MarcoIeni/release-plz/""##;
+    const FOLDER: &str = ".schema/";
+    const FILE: &str = "latest.json";
+
+    let schema = schema_for!(config::Config);
+    let mut json = serde_json::to_string_pretty(&schema).unwrap();
+    // As of now, Schemars does not support the $id field, so we insert it manually.
+    // See here for update on resolution: https://github.com/GREsau/schemars/issues/229
+    json = json.replace(
+        SCHEMA_TOKEN,
+        &format!("{}\n  {}{}{}", SCHEMA_TOKEN, ID, FOLDER, FILE),
+    );
+    fs::create_dir_all(FOLDER).unwrap();
+    fs::write(&format!("{}{}", FOLDER, FILE), json).unwrap();
+}

--- a/crates/release_plz/src/main.rs
+++ b/crates/release_plz/src/main.rs
@@ -1,8 +1,8 @@
 mod args;
 mod config;
+mod generate_schema;
 mod log;
 mod update_checker;
-mod generate_schema;
 
 use anyhow::Context;
 use clap::Parser;
@@ -54,7 +54,7 @@ async fn run(args: CliArgs) -> anyhow::Result<()> {
         }
         Command::GenerateCompletions(cmd_args) => cmd_args.print(),
         Command::CheckUpdates => update_checker::check_update().await?,
-        Command::GenerateSchema => {generate_schema::generate_schema()}
+        Command::GenerateSchema => generate_schema::generate_schema(),
     }
     Ok(())
 }

--- a/crates/release_plz/src/main.rs
+++ b/crates/release_plz/src/main.rs
@@ -2,13 +2,14 @@ mod args;
 mod config;
 mod log;
 mod update_checker;
+mod generate_schema;
 
 use anyhow::Context;
 use clap::Parser;
 use release_plz_core::{ReleasePrRequest, ReleaseRequest};
 use tracing::error;
 
-use crate::args::CliArgs;
+use crate::args::{CliArgs, Command};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -24,13 +25,13 @@ async fn main() -> anyhow::Result<()> {
 
 async fn run(args: CliArgs) -> anyhow::Result<()> {
     match args.command {
-        args::Command::Update(cmd_args) => {
+        Command::Update(cmd_args) => {
             let config = cmd_args.config()?;
             let update_request = cmd_args.update_request(config)?;
             let updates = release_plz_core::update(&update_request)?;
             println!("{}", updates.0.summary());
         }
-        args::Command::ReleasePr(cmd_args) => {
+        Command::ReleasePr(cmd_args) => {
             let config = cmd_args.update.config()?;
             let pr_labels = config.workspace.release_pr.pr_labels.clone();
             let pr_draft = config.workspace.release_pr.pr_draft;
@@ -46,13 +47,14 @@ async fn run(args: CliArgs) -> anyhow::Result<()> {
                 .with_labels(pr_labels);
             release_plz_core::release_pr(&request).await?;
         }
-        args::Command::Release(cmd_args) => {
+        Command::Release(cmd_args) => {
             let config = cmd_args.config()?;
             let request: ReleaseRequest = cmd_args.release_request(config)?;
             release_plz_core::release(&request).await?;
         }
-        args::Command::GenerateCompletions(cmd_args) => cmd_args.print(),
-        args::Command::CheckUpdates => update_checker::check_update().await?,
+        Command::GenerateCompletions(cmd_args) => cmd_args.print(),
+        Command::CheckUpdates => update_checker::check_update().await?,
+        Command::GenerateSchema => {generate_schema::generate_schema()}
     }
     Ok(())
 }

--- a/website/docs/usage/generate-schema.md
+++ b/website/docs/usage/generate-schema.md
@@ -1,0 +1,7 @@
+# generate-schema
+The `release-plz generate-schema` command will generate a JSON schema for the configuration file.
+The file will be generated as `.schema/latest.json`.
+
+This command is mostly meant for development purposes and will be generated when new configurations are added.
+It will be referenced on https://www.schemastore.org/json/ to allow supported IDEs to autocomplete
+and validate the configuration file.

--- a/website/docs/usage/index.md
+++ b/website/docs/usage/index.md
@@ -8,5 +8,6 @@ There are three main commands:
   committing any change.
 - [`release-plz release-pr`](release-pr.md) opens a GitHub Pull Request.
 - [`release-plz release`](release.md) publishes the new versions of the packages.
+- [`release-plz generate-schema`](generate-schema.md) generates the configuration schema.
 
 To learn more about how to use release-plz, run `release-plz --help`.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -26,6 +26,7 @@ const sidebars = {
         "usage/release-pr",
         "usage/release",
         "usage/shell-completion",
+        "usage/generate-schema",
       ],
     },
     {


### PR DESCRIPTION
- New generate-schema command
- Updated the documentation
- Added the first iteration of the schema to then create a PR on SchemaStore once merged into main
- New CI check that there are no uncommitted changes to the schema in the PR 