### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.32](https://github.com/MarcoIeni/release-plz/compare/release-plz-v0.3.31...release-plz-v0.3.32) - 2023-12-04
+
+### Fixed
+- support projects with external readme ([#1110](https://github.com/MarcoIeni/release-plz/pull/1110))
+- pass full commit message to git-cliff ([#1103](https://github.com/MarcoIeni/release-plz/pull/1103)) ([#1104](https://github.com/MarcoIeni/release-plz/pull/1104))
+
+### Other
+- update dependencies
+
 ## [0.3.31](https://github.com/MarcoIeni/release-plz/compare/release-plz-v0.3.30...release-plz-v0.3.31) - 2023-11-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,30 +76,30 @@ checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "a3a318f1f38d2418400f8209655bfd825785afd25aa30bb7ba6cc792e4596748"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -629,9 +629,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concurrent-queue"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -894,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
 dependencies = [
  "powerfmt",
  "serde",
@@ -4149,7 +4149,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "release-plz"
-version = "0.3.31"
+version = "0.3.32"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -4183,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "release_plz_core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "cargo",
@@ -4399,15 +4399,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.25"
+version = "0.38.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5717,9 +5717,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.19"
+version = "0.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
+checksum = "12b1ca33e6ddf286f444aca4f9e91152c681bf93c491687d43cd69bd5078fb4b"
 dependencies = [
  "memchr",
 ]
@@ -5767,18 +5767,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43de342578a3a14a9314a2dab1942cbfcbe5686e1f91acdc513058063eafe18"
+checksum = "7d6f15f7ade05d2a4935e34a457b936c23dc70a05cc1d97133dc99e7a3fe0f0e"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.27"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1012d89e3acb79fad7a799ce96866cfb8098b74638465ea1b1533d35900ca90"
+checksum = "dbbad221e3f78500350ecbd7dfa4e63ef945c05f4c61cb7f4d3f84cd0bba649b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/release_plz/Cargo.toml
+++ b/crates/release_plz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release-plz"
-version = "0.3.31"
+version = "0.3.32"
 edition = "2021"
 description = "Update version and changelog based on semantic versioning and conventional commits"
 repository = "https://github.com/MarcoIeni/release-plz"
@@ -20,7 +20,7 @@ docker-tests = []
 
 [dependencies]
 git_cmd = { path = "../git_cmd", version = "0.4.14" }
-release_plz_core = { path = "../release_plz_core", version = "0.15.0" }
+release_plz_core = { path = "../release_plz_core", version = "0.15.1" }
 
 anyhow.workspace = true
 base64.workspace = true

--- a/crates/release_plz_core/CHANGELOG.md
+++ b/crates/release_plz_core/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1](https://github.com/MarcoIeni/release-plz/compare/release_plz_core-v0.15.0...release_plz_core-v0.15.1) - 2023-12-04
+
+### Fixed
+- support projects with external readme ([#1110](https://github.com/MarcoIeni/release-plz/pull/1110))
+- pass full commit message to git-cliff ([#1103](https://github.com/MarcoIeni/release-plz/pull/1103)) ([#1104](https://github.com/MarcoIeni/release-plz/pull/1104))
+
 ## [0.15.0](https://github.com/MarcoIeni/release-plz/compare/release_plz_core-v0.14.5...release_plz_core-v0.15.0) - 2023-11-30
 
 ### Added

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release_plz_core"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 description = "Update version and changelog based on semantic versioning and conventional commits"
 repository = "https://github.com/MarcoIeni/release-plz/tree/main/crates/release_plz_core"


### PR DESCRIPTION
## 🤖 New release
* `release-plz`: 0.3.31 -> 0.3.32
* `release_plz_core`: 0.15.0 -> 0.15.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `release-plz`
<blockquote>

## [0.3.32](https://github.com/MarcoIeni/release-plz/compare/release-plz-v0.3.31...release-plz-v0.3.32) - 2023-12-04

### Fixed
- support projects with external readme ([#1110](https://github.com/MarcoIeni/release-plz/pull/1110))
- pass full commit message to git-cliff ([#1103](https://github.com/MarcoIeni/release-plz/pull/1103)) ([#1104](https://github.com/MarcoIeni/release-plz/pull/1104))

### Other
- update dependencies
</blockquote>

## `release_plz_core`
<blockquote>

## [0.15.1](https://github.com/MarcoIeni/release-plz/compare/release_plz_core-v0.15.0...release_plz_core-v0.15.1) - 2023-12-04

### Fixed
- support projects with external readme ([#1110](https://github.com/MarcoIeni/release-plz/pull/1110))
- pass full commit message to git-cliff ([#1103](https://github.com/MarcoIeni/release-plz/pull/1103)) ([#1104](https://github.com/MarcoIeni/release-plz/pull/1104))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).