### PR TITLE
chore(args): hide the environment value of git token

### DIFF
--- a/crates/release_plz/src/args/release.rs
+++ b/crates/release_plz/src/args/release.rs
@@ -44,7 +44,7 @@ pub struct Release {
     #[arg(long, value_parser = NonEmptyStringValueParser::new())]
     pub repo_url: Option<String>,
     /// Git token used to publish the GitHub release.
-    #[arg(long, value_parser = NonEmptyStringValueParser::new(), env)]
+    #[arg(long, value_parser = NonEmptyStringValueParser::new(), env, hide_env_values=true)]
     pub git_token: Option<String>,
     /// Kind of git backend
     #[arg(long, value_enum, default_value_t = ReleaseGitBackendKind::Github)]

--- a/crates/release_plz/src/args/release_pr.rs
+++ b/crates/release_plz/src/args/release_pr.rs
@@ -13,7 +13,7 @@ pub struct ReleasePr {
     #[command(flatten)]
     pub update: Update,
     /// Git token used to create the pull request.
-    #[arg(long, value_parser = NonEmptyStringValueParser::new(), visible_alias = "github-token", env)]
+    #[arg(long, value_parser = NonEmptyStringValueParser::new(), visible_alias = "github-token", env, hide_env_values=true)]
     git_token: String,
     /// Kind of git host where your project is hosted.
     #[arg(long, value_enum, default_value_t = GitBackendKind::Github)]


### PR DESCRIPTION
Fixes this security issue:

```sh
$ GIT_TOKEN=pwned release-plz release-pr --help

Options:
  ...
  --git-token <GIT_TOKEN>
      Git token used to create the pull request [env: GIT_TOKEN=pwned] [aliases: github-token]
```
