### PR TITLE
fix: Correct dependency update behavior for release-pr

### DIFF
--- a/crates/release_plz_core/src/command/update.rs
+++ b/crates/release_plz_core/src/command/update.rs
@@ -131,6 +131,8 @@ pub fn update(input: &UpdateRequest) -> anyhow::Result<(PackagesUpdate, TempRepo
         crate::next_versions(input).context("failed to determine next versions")?;
     let local_manifest_path = input.local_manifest();
     let local_metadata = cargo_utils::get_manifest_metadata(local_manifest_path)?;
+    // Read packages from `local_metadata` to update the manifest of local
+    // workspace dependencies.
     let all_packages: Vec<Package> = cargo_utils::workspace_members(&local_metadata)?.collect();
     update_manifests(&packages_to_update, local_manifest_path, &all_packages)?;
     update_changelogs(input, &packages_to_update)?;

--- a/crates/release_plz_core/src/command/update.rs
+++ b/crates/release_plz_core/src/command/update.rs
@@ -130,8 +130,8 @@ pub fn update(input: &UpdateRequest) -> anyhow::Result<(PackagesUpdate, TempRepo
     let (packages_to_update, repository) =
         crate::next_versions(input).context("failed to determine next versions")?;
     let local_manifest_path = input.local_manifest();
-    let all_packages: Vec<Package> =
-        cargo_utils::workspace_members(input.cargo_metadata())?.collect();
+    let local_metadata = cargo_utils::get_manifest_metadata(local_manifest_path)?;
+    let all_packages: Vec<Package> = cargo_utils::workspace_members(&local_metadata)?.collect();
     update_manifests(&packages_to_update, local_manifest_path, &all_packages)?;
     update_changelogs(input, &packages_to_update)?;
     if !packages_to_update.updates.is_empty() {


### PR DESCRIPTION
Changed the update command to use cargo metadata from the tmp manifest, which give it the correct dependency paths used for comparison during dependency updates.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
