### PR TITLE
feat: add pre-release option

### DIFF
--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -181,12 +181,9 @@ impl From<PackageConfig> for release_plz_core::ReleaseConfig {
         let is_publish_enabled = value.publish != Some(false);
         let is_git_release_enabled = value.git_release_enable != Some(false);
         let is_git_release_draft = value.git_release_draft == Some(true);
-        let git_release_type = match value.git_release_type {
-            Some(ReleaseType::Prod) => Some(release_plz_core::ReleaseType::Prod),
-            Some(ReleaseType::Pre) => Some(release_plz_core::ReleaseType::Pre),
-            Some(ReleaseType::Auto) => Some(release_plz_core::ReleaseType::Auto),
-            None => None,
-        };
+        let git_release_type: Option<release_plz_core::ReleaseType> = value
+            .git_release_type
+            .map(|release_type| release_type.into());
         let is_git_tag_enabled = value.git_tag_enable != Some(false);
         let release = value.release != Some(false);
         let mut cfg = Self::default()
@@ -315,6 +312,16 @@ pub enum ReleaseType {
     /// in case there is a semver pre-release in the tag e.g. v1.0.0-rc1.
     /// Otherwise, will mark the release as ready for production.
     Auto,
+}
+
+impl From<ReleaseType> for release_plz_core::ReleaseType {
+    fn from(value: ReleaseType) -> Self {
+        match value {
+            ReleaseType::Prod => Self::Prod,
+            ReleaseType::Pre => Self::Pre,
+            ReleaseType::Auto => Self::Auto,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -181,9 +181,10 @@ impl From<PackageConfig> for release_plz_core::ReleaseConfig {
         let is_publish_enabled = value.publish != Some(false);
         let is_git_release_enabled = value.git_release_enable != Some(false);
         let is_git_release_draft = value.git_release_draft == Some(true);
-        let git_release_type: Option<release_plz_core::ReleaseType> = value
+        let git_release_type: release_plz_core::ReleaseType = value
             .git_release_type
-            .map(|release_type| release_type.into());
+            .map(|release_type| release_type.into())
+            .unwrap_or_default();
         let is_git_tag_enabled = value.git_tag_enable != Some(false);
         let release = value.release != Some(false);
         let mut cfg = Self::default()

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -181,7 +181,12 @@ impl From<PackageConfig> for release_plz_core::ReleaseConfig {
         let is_publish_enabled = value.publish != Some(false);
         let is_git_release_enabled = value.git_release_enable != Some(false);
         let is_git_release_draft = value.git_release_draft == Some(true);
-        let is_git_pre_release = value.git_release_type == Some(ReleaseType::Pre);
+        let git_release_type = match value.git_release_type {
+            Some(ReleaseType::Prod) => Some(release_plz_core::ReleaseType::Prod),
+            Some(ReleaseType::Pre) => Some(release_plz_core::ReleaseType::Pre),
+            Some(ReleaseType::Auto) => Some(release_plz_core::ReleaseType::Auto),
+            None => None,
+        };
         let is_git_tag_enabled = value.git_tag_enable != Some(false);
         let release = value.release != Some(false);
         let mut cfg = Self::default()
@@ -189,7 +194,7 @@ impl From<PackageConfig> for release_plz_core::ReleaseConfig {
             .with_git_release(
                 release_plz_core::GitReleaseConfig::enabled(is_git_release_enabled)
                     .set_draft(is_git_release_draft)
-                    .set_pre_release(is_git_pre_release),
+                    .set_release_type(git_release_type),
             )
             .with_git_tag(release_plz_core::GitTagConfig::enabled(is_git_tag_enabled))
             .with_release(release);

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -181,13 +181,15 @@ impl From<PackageConfig> for release_plz_core::ReleaseConfig {
         let is_publish_enabled = value.publish != Some(false);
         let is_git_release_enabled = value.git_release_enable != Some(false);
         let is_git_release_draft = value.git_release_draft == Some(true);
+        let is_git_pre_release = value.git_release_type == Some(ReleaseType::Pre);
         let is_git_tag_enabled = value.git_tag_enable != Some(false);
         let release = value.release != Some(false);
         let mut cfg = Self::default()
             .with_publish(release_plz_core::PublishConfig::enabled(is_publish_enabled))
             .with_git_release(
                 release_plz_core::GitReleaseConfig::enabled(is_git_release_enabled)
-                    .set_draft(is_git_release_draft),
+                    .set_draft(is_git_release_draft)
+                    .set_pre_release(is_git_pre_release),
             )
             .with_git_tag(release_plz_core::GitTagConfig::enabled(is_git_tag_enabled))
             .with_release(release);

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -288,7 +288,7 @@ pub enum ReleaseType {
 pub struct GitReleaseConfig {
     enabled: bool,
     draft: bool,
-    release_type: Option<ReleaseType>,
+    release_type: ReleaseType,
 }
 
 impl Default for GitReleaseConfig {
@@ -302,7 +302,7 @@ impl GitReleaseConfig {
         Self {
             enabled,
             draft: false,
-            release_type: Some(ReleaseType::Prod),
+            release_type: ReleaseType::default(),
         }
     }
 
@@ -315,19 +315,19 @@ impl GitReleaseConfig {
         self
     }
 
-    pub fn set_release_type(mut self, release_type: Option<ReleaseType>) -> Self {
+    pub fn set_release_type(mut self, release_type: ReleaseType) -> Self {
         self.release_type = release_type;
         self
     }
 
     pub fn is_pre_release(&self, git_tag: &str) -> bool {
         match self.release_type {
-            Some(ReleaseType::Pre) => true,
-            Some(ReleaseType::Auto) => match Version::parse(git_tag.trim_start_matches('v')) {
+            ReleaseType::Pre => true,
+            ReleaseType::Auto => match Version::parse(git_tag.trim_start_matches('v')) {
                 Ok(v) => v.is_prerelease(),
                 Err(_) => false,
             },
-            Some(ReleaseType::Prod) | None => false,
+            ReleaseType::Prod => false,
         }
     }
 }
@@ -599,7 +599,7 @@ mod tests {
     #[test]
     fn git_release_config_pre_release_auto_works() {
         let mut config = GitReleaseConfig::default();
-        config = config.set_release_type(Some(ReleaseType::Auto));
+        config = config.set_release_type(ReleaseType::Auto);
         assert!(config.is_pre_release("v1.0.0-rc1"));
         assert!(!config.is_pre_release("v1.0.0"));
     }
@@ -607,7 +607,7 @@ mod tests {
     #[test]
     fn git_release_config_pre_release_pre_works() {
         let mut config = GitReleaseConfig::default();
-        config = config.set_release_type(Some(ReleaseType::Pre));
+        config = config.set_release_type(ReleaseType::Pre);
         assert!(config.is_pre_release("v1.0.0-rc1"));
         assert!(config.is_pre_release("v1.0.0"));
     }

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -279,6 +279,7 @@ impl PublishConfig {
 pub struct GitReleaseConfig {
     enabled: bool,
     draft: bool,
+    pre_release: bool,
 }
 
 impl Default for GitReleaseConfig {
@@ -292,6 +293,7 @@ impl GitReleaseConfig {
         Self {
             enabled,
             draft: false,
+            pre_release: false,
         }
     }
 
@@ -301,6 +303,11 @@ impl GitReleaseConfig {
 
     pub fn set_draft(mut self, draft: bool) -> Self {
         self.draft = draft;
+        self
+    }
+
+    pub fn set_pre_release(mut self, pre_release: bool) -> Self {
+        self.pre_release = pre_release;
         self
     }
 }
@@ -464,15 +471,13 @@ async fn release_package(
                 .as_ref()
                 .context("git release not configured. Did you specify git-token and backend?")?;
             let release_body = release_body(input, package);
-            let is_release_draft = input
-                .get_package_config(&package.name)
-                .generic
-                .git_release
-                .draft;
+            let release_config = input.get_package_config(&package.name).generic.git_release;
+            // let is_pre_release = release_config.
             let release_info = GitReleaseInfo {
                 git_tag,
                 release_body,
-                draft: is_release_draft,
+                draft: release_config.draft,
+                pre_release: release_config.pre_release,
             };
             publish_git_release(&release_info, &git_release.backend).await?;
         }
@@ -487,6 +492,7 @@ pub struct GitReleaseInfo {
     pub git_tag: String,
     pub release_body: String,
     pub draft: bool,
+    pub pre_release: bool,
 }
 
 fn run_cargo_publish(

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -472,7 +472,6 @@ async fn release_package(
                 .context("git release not configured. Did you specify git-token and backend?")?;
             let release_body = release_body(input, package);
             let release_config = input.get_package_config(&package.name).generic.git_release;
-            // let is_pre_release = release_config.
             let release_info = GitReleaseInfo {
                 git_tag,
                 release_body,

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -72,6 +72,7 @@ pub struct CreateReleaseOption<'a> {
     body: &'a str,
     name: &'a str,
     draft: &'a bool,
+    prerelease: &'a bool,
 }
 
 #[derive(Deserialize)]
@@ -187,6 +188,7 @@ impl GitClient {
             body: &release_info.release_body,
             name: &release_info.git_tag,
             draft: &release_info.draft,
+            prerelease: &release_info.pre_release,
         };
         self.client
             .post(format!("{}/releases", self.repo_url()))

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -73,7 +73,7 @@ the following sections:
   - [`changelog_path`](#the-changelog_path-field-package-section) — Changelog path.
   - [`changelog_update`](#the-changelog_update-field-package-section) — Update changelog.
   - [`git_release_enable`](#the-git_release_enable-field-package-section) — Enable git release.
-  - [`git_release_type`](#the-git_release_type-field-package-section) — Publish mode for git release.
+  - [`git_release_type`](#the-git_release_type-field-package-section) — Git release type.
   - [`git_release_draft`](#the-git_release_draft-field-package-section) — Publish git release as draft.
   - [`git_tag_enable`](#the-git_tag_enable-field-package-section) — Enable git tag.
   - [`publish`](#the-publish-field-package-section) — Publish to cargo registry.
@@ -146,7 +146,8 @@ The supported git releases are:
 
 #### The `git_release_type` field
 
-The publish mode for a release. Supported modes are:
+Define whether to label the release as production or non-production ready.
+Supported values are:
 
 - `"prod"`: will mark the release as ready for production. *(Default)*.
 - `"pre"`: will mark the release as not ready for production (pre-release).

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -55,10 +55,11 @@ the following sections:
   - [`changelog_update`](#the-changelog_update-field) — Update changelog.
   - [`dependencies_update`](#the-dependencies_update-field) — Update all dependencies.
   - [`git_release_enable`](#the-git_release_enable-field) — Enable git release.
-  - [`git_release_draft`](#the-git_release_draft-field) — Publish git release as draft.
+  - [`git_release_type`](#the-git_release_type-field) — Publish mode for git release. *(GitHub, Gitea only)*.
+  - [`git_release_draft`](#the-git_release_draft-field) — Publish git release as draft. *(GitHub, Gitea only)*.
   - [`git_tag_enable`](#the-git_tag_enable-field) — Enable git tag.
   - [`pr_draft`](#the-pr_draft-field) — Open the release Pull Request as a draft.
-  - [`pr_labels`](#the-pr_labels-field) — Add labels to the release Pull Request.
+  - [`pr_labels`](#the-pr_labels-field) — Add labels to the release Pull Request. *(GitHub only)*.
   - [`publish`](#the-publish-field) — Publish to cargo registry.
   - [`publish_allow_dirty`](#the-publish_allow_dirty-field) — Package dirty directories.
   - [`publish_no_verify`](#the-publish_no_verify-field) — Don't verify package build.
@@ -72,7 +73,8 @@ the following sections:
   - [`changelog_path`](#the-changelog_path-field-package-section) — Changelog path.
   - [`changelog_update`](#the-changelog_update-field-package-section) — Update changelog.
   - [`git_release_enable`](#the-git_release_enable-field-package-section) — Enable git release.
-  - [`git_release_draft`](#the-git_release_draft-field-package-section) — Publish git release as draft.
+  - [`git_release_type`](#the-git_release_type-field-package-section) — Publish mode for git release. *(GitHub, Gitea only)*.
+  - [`git_release_draft`](#the-git_release_draft-field-package-section) — Publish git release as draft. *(GitHub, Gitea only)*.
   - [`git_tag_enable`](#the-git_tag_enable-field-package-section) — Enable git tag.
   - [`publish`](#the-publish-field-package-section) — Publish to cargo registry.
   - [`publish_allow_dirty`](#the-publish_allow_dirty-field-package-section) — Package dirty directories.
@@ -142,10 +144,20 @@ The supported git releases are:
 - [Gitea](https://docs.gitea.io/en-us/)
 - [GitLab](https://docs.gitlab.com/ee/user/project/releases/#releases)
 
+#### The `git_release_type` field
+
+The publish mode for a release. Supported modes are *(GitHub, Gitea only)*:
+
+- `Prod`: will mark the release as ready for production. *(Default)*.
+- `Pre`: will mark the release as not ready for production (pre-release).
+- `Auto`: will mark the release as not ready for production in case there is a semver pre-release in the tag e.g. v1.0.0-rc1. Otherwise it will be marked as ready for production.
+
+
 #### The `git_release_draft` field
 
-- If `true`, release-plz creates the git release as draft (unpublished).
+- If `true`, release-plz creates the git release as draft (unpublished). *(GitHub, Gitea only)*.
 - If `false`, release-plz publishes the created git release. *(Default)*.
+
 
 #### The `git_tag_enable` field
 
@@ -333,9 +345,14 @@ This field cannot be set in the `[workspace]` section.
 
 Overrides the [`workspace.git_release_enable`](#the-git_release_enable-field) field.
 
+#### The `git_release_type` field (`package` section)
+
+Overrides the [`workspace.git_release_type`](#the-git_release_type-field) field. *(GitHub, Gitea only)*.
+
+
 #### The `git_release_draft` field (`package` section)
 
-Overrides the [`workspace.git_release_draft`](#the-git_release_draft-field) field.
+Overrides the [`workspace.git_release_draft`](#the-git_release_draft-field) field. *(GitHub, Gitea only)*.
 
 #### The `git_tag_enable` field (`package` section)
 

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -56,13 +56,10 @@ the following sections:
   - [`dependencies_update`](#the-dependencies_update-field) — Update all dependencies.
   - [`git_release_enable`](#the-git_release_enable-field) — Enable git release.
   - [`git_release_type`](#the-git_release_type-field) — Publish mode for git release.
-    *(GitHub, Gitea only)*.
   - [`git_release_draft`](#the-git_release_draft-field) — Publish git release as draft.
-    *(GitHub, Gitea only)*.
   - [`git_tag_enable`](#the-git_tag_enable-field) — Enable git tag.
   - [`pr_draft`](#the-pr_draft-field) — Open the release Pull Request as a draft.
   - [`pr_labels`](#the-pr_labels-field) — Add labels to the release Pull Request.
-    *(GitHub only)*.
   - [`publish`](#the-publish-field) — Publish to cargo registry.
   - [`publish_allow_dirty`](#the-publish_allow_dirty-field) — Package dirty directories.
   - [`publish_no_verify`](#the-publish_no_verify-field) — Don't verify package build.
@@ -77,9 +74,7 @@ the following sections:
   - [`changelog_update`](#the-changelog_update-field-package-section) — Update changelog.
   - [`git_release_enable`](#the-git_release_enable-field-package-section) — Enable git release.
   - [`git_release_type`](#the-git_release_type-field-package-section) — Publish mode for git release.
-    *(GitHub, Gitea only)*.
   - [`git_release_draft`](#the-git_release_draft-field-package-section) — Publish git release as draft.
-    *(GitHub, Gitea only)*.
   - [`git_tag_enable`](#the-git_tag_enable-field-package-section) — Enable git tag.
   - [`publish`](#the-publish-field-package-section) — Publish to cargo registry.
   - [`publish_allow_dirty`](#the-publish_allow_dirty-field-package-section) — Package dirty directories.
@@ -151,17 +146,24 @@ The supported git releases are:
 
 #### The `git_release_type` field
 
-The publish mode for a release. Supported modes are *(GitHub, Gitea only)*:
+The publish mode for a release. Supported modes are:
 
-- `Prod`: will mark the release as ready for production. *(Default)*.
-- `Pre`: will mark the release as not ready for production (pre-release).
-- `Auto`: will mark the release as not ready for production in case there is a semver pre-release
-  in the tag e.g. v1.0.0-rc1. Otherwise it will be marked as ready for production.
+- `"prod"`: will mark the release as ready for production. *(Default)*.
+- `"pre"`: will mark the release as not ready for production (pre-release).
+- `"auto"`:
+  - if there's a SemVer pre-release in the version (e.g. `v1.0.0-rc1`), will mark the release as
+    not ready for production (pre-release).
+  - if there isn't a semver pre-release in the version (e.g. `v1.0.0`), will mark the release as
+    ready for production.
+
+*(GitHub, Gitea only)*.
 
 #### The `git_release_draft` field
 
-- If `true`, release-plz creates the git release as draft (unpublished). *(GitHub, Gitea only)*.
+- If `true`, release-plz creates the git release as draft (unpublished).
 - If `false`, release-plz publishes the created git release. *(Default)*.
+
+*(GitHub, Gitea only)*.
 
 #### The `git_tag_enable` field
 
@@ -351,11 +353,11 @@ Overrides the [`workspace.git_release_enable`](#the-git_release_enable-field) fi
 
 #### The `git_release_type` field (`package` section)
 
-Overrides the [`workspace.git_release_type`](#the-git_release_type-field) field. *(GitHub, Gitea only)*.
+Overrides the [`workspace.git_release_type`](#the-git_release_type-field) field.
 
 #### The `git_release_draft` field (`package` section)
 
-Overrides the [`workspace.git_release_draft`](#the-git_release_draft-field) field. *(GitHub, Gitea only)*.
+Overrides the [`workspace.git_release_draft`](#the-git_release_draft-field) field.
 
 #### The `git_tag_enable` field (`package` section)
 

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -155,14 +155,13 @@ The publish mode for a release. Supported modes are *(GitHub, Gitea only)*:
 
 - `Prod`: will mark the release as ready for production. *(Default)*.
 - `Pre`: will mark the release as not ready for production (pre-release).
-- `Auto`: will mark the release as not ready for production in case there is a semver pre-release in the tag e.g. v1.0.0-rc1. Otherwise it will be marked as ready for production.
-
+- `Auto`: will mark the release as not ready for production in case there is a semver pre-release
+  in the tag e.g. v1.0.0-rc1. Otherwise it will be marked as ready for production.
 
 #### The `git_release_draft` field
 
 - If `true`, release-plz creates the git release as draft (unpublished). *(GitHub, Gitea only)*.
 - If `false`, release-plz publishes the created git release. *(Default)*.
-
 
 #### The `git_tag_enable` field
 
@@ -353,7 +352,6 @@ Overrides the [`workspace.git_release_enable`](#the-git_release_enable-field) fi
 #### The `git_release_type` field (`package` section)
 
 Overrides the [`workspace.git_release_type`](#the-git_release_type-field) field. *(GitHub, Gitea only)*.
-
 
 #### The `git_release_draft` field (`package` section)
 

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -55,11 +55,14 @@ the following sections:
   - [`changelog_update`](#the-changelog_update-field) — Update changelog.
   - [`dependencies_update`](#the-dependencies_update-field) — Update all dependencies.
   - [`git_release_enable`](#the-git_release_enable-field) — Enable git release.
-  - [`git_release_type`](#the-git_release_type-field) — Publish mode for git release. *(GitHub, Gitea only)*.
-  - [`git_release_draft`](#the-git_release_draft-field) — Publish git release as draft. *(GitHub, Gitea only)*.
+  - [`git_release_type`](#the-git_release_type-field) — Publish mode for git release.
+    *(GitHub, Gitea only)*.
+  - [`git_release_draft`](#the-git_release_draft-field) — Publish git release as draft.
+    *(GitHub, Gitea only)*.
   - [`git_tag_enable`](#the-git_tag_enable-field) — Enable git tag.
   - [`pr_draft`](#the-pr_draft-field) — Open the release Pull Request as a draft.
-  - [`pr_labels`](#the-pr_labels-field) — Add labels to the release Pull Request. *(GitHub only)*.
+  - [`pr_labels`](#the-pr_labels-field) — Add labels to the release Pull Request.
+    *(GitHub only)*.
   - [`publish`](#the-publish-field) — Publish to cargo registry.
   - [`publish_allow_dirty`](#the-publish_allow_dirty-field) — Package dirty directories.
   - [`publish_no_verify`](#the-publish_no_verify-field) — Don't verify package build.
@@ -73,8 +76,10 @@ the following sections:
   - [`changelog_path`](#the-changelog_path-field-package-section) — Changelog path.
   - [`changelog_update`](#the-changelog_update-field-package-section) — Update changelog.
   - [`git_release_enable`](#the-git_release_enable-field-package-section) — Enable git release.
-  - [`git_release_type`](#the-git_release_type-field-package-section) — Publish mode for git release. *(GitHub, Gitea only)*.
-  - [`git_release_draft`](#the-git_release_draft-field-package-section) — Publish git release as draft. *(GitHub, Gitea only)*.
+  - [`git_release_type`](#the-git_release_type-field-package-section) — Publish mode for git release.
+    *(GitHub, Gitea only)*.
+  - [`git_release_draft`](#the-git_release_draft-field-package-section) — Publish git release as draft.
+    *(GitHub, Gitea only)*.
   - [`git_tag_enable`](#the-git_tag_enable-field-package-section) — Enable git tag.
   - [`publish`](#the-publish-field-package-section) — Publish to cargo registry.
   - [`publish_allow_dirty`](#the-publish_allow_dirty-field-package-section) — Package dirty directories.


### PR DESCRIPTION
Closes #678 

This pull request adds the ability to set a release type mode for GitHub and Gitea. It uses the modes which where defined beforehand:

- Prod: ready for production
- Pre: pre-release
- Auto: pre-release detection based on a semver version within the git tag