### PR TITLE
Don't rely on stderr to check for success

### DIFF
--- a/crates/release_plz_core/src/cargo.rs
+++ b/crates/release_plz_core/src/cargo.rs
@@ -53,6 +53,15 @@ pub fn run_cargo(root: &Path, args: &[&str]) -> anyhow::Result<(String, String)>
     debug!("cargo stderr: {}", output_stderr);
     debug!("cargo stdout: {}", output_stdout);
 
+    if !output.status.success() {
+        anyhow::bail!(
+            "cargo {} failed with {}. stderr: {}",
+            args.join(" "),
+            output.status,
+            output_stderr
+        );
+    }
+
     Ok((
         output_stdout.trim().to_owned(),
         output_stderr.trim().to_owned(),

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -99,11 +99,7 @@ fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> anyhow::Result<()> {
 fn run_cargo_package(package: &Path) -> anyhow::Result<String> {
     // we use `--allow-dirty` because we have `Cargo.toml.orig.orig`, which is an uncommitted change.
     let args = ["package", "--list", "--quiet", "--allow-dirty"];
-    let (stdout, stderr) = run_cargo(package, &args).context("cannot run `cargo package`")?;
-
-    if !stderr.is_empty() {
-        anyhow::bail!("error while running `cargo package`: {stderr}");
-    }
+    let (stdout, _stderr) = run_cargo(package, &args).context("cannot run `cargo package`")?;
 
     Ok(stdout)
 }


### PR DESCRIPTION
Have run-cargo check for the exit code instead,
show stderr if it was nonzero.

Closes #1203 and #1233

(Also, is a duplicate of #1234 I've just noticed, woops)