### PR TITLE
fix: update local dependencies specified in the workspace manifest

### DIFF
--- a/crates/release_plz_core/src/command/update.rs
+++ b/crates/release_plz_core/src/command/update.rs
@@ -293,11 +293,12 @@ fn update_dependencies(
     package_path: &Path,
     workspace_manifest: &Path,
 ) -> anyhow::Result<()> {
-    for manifest in iter::once(workspace_manifest).chain(
+    let all_manifests = iter::once(workspace_manifest).chain(
         all_packages
             .iter()
             .map(|pkg| pkg.manifest_path.as_std_path()),
-    ) {
+    );
+    for manifest in all_manifests {
         let mut local_manifest = LocalManifest::try_new(manifest)?;
         let manifest_dir = crate::manifest_dir(&local_manifest.path)?.to_owned();
         let deps_to_update = local_manifest


### PR DESCRIPTION
<!-- Please explain the changes you made -->
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
We've encountered issues when [using release-plz at lumina](https://github.com/eigerco/lumina/actions/runs/7783144141/job/21220976044#step:5:225). It seems like currently `release-plz` is capable of updating dependencies specified directly in packages' manifests and is ignoring dependencies specified on workspace level. The latter doesn't get version bumps which results in failures in resolving.

I'm not sure if there are additional things needed when updating also workspace-wide dependencies tho. Let me know wdyt