### PR TITLE
feat-custom-git-tag-name-by-tera-template

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -44,6 +44,7 @@
         "git_release_enable": null,
         "git_release_type": null,
         "git_tag_enable": null,
+        "git_tag_name": null,
         "pr_draft": false,
         "pr_labels": [],
         "publish": null,
@@ -300,6 +301,14 @@
             "null"
           ]
         },
+        "git_tag_name": {
+          "title": "Git Tag Name",
+          "description": "The name of the tag. It can be a tera template.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "name": {
           "type": "string"
         },
@@ -476,6 +485,14 @@
           "description": "Publish the git tag for the new package version. Enabled by default.",
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "git_tag_name": {
+          "title": "Git Tag Name",
+          "description": "The name of the tag. It can be a tera template.",
+          "type": [
+            "string",
             "null"
           ]
         },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4228,6 +4228,7 @@ dependencies = [
  "serde_json",
  "strip-ansi-escapes",
  "tempfile",
+ "tera",
  "test_logs",
  "tokio",
  "toml 0.8.8",

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -190,6 +190,7 @@ impl From<PackageConfig> for release_plz_core::ReleaseConfig {
             .map(|release_type| release_type.into())
             .unwrap_or_default();
         let is_git_tag_enabled = value.git_tag_enable != Some(false);
+        let git_tag_name = value.git_tag_name.clone();
         let release = value.release != Some(false);
         let mut cfg = Self::default()
             .with_publish(release_plz_core::PublishConfig::enabled(is_publish_enabled))
@@ -198,7 +199,10 @@ impl From<PackageConfig> for release_plz_core::ReleaseConfig {
                     .set_draft(is_git_release_draft)
                     .set_release_type(git_release_type),
             )
-            .with_git_tag(release_plz_core::GitTagConfig::enabled(is_git_tag_enabled))
+            .with_git_tag(
+                release_plz_core::GitTagConfig::enabled(is_git_tag_enabled)
+                    .set_name_template(git_tag_name),
+            )
             .with_release(release);
 
         if let Some(no_verify) = value.publish_no_verify {
@@ -232,6 +236,9 @@ pub struct PackageConfig {
     /// Publish the git tag for the new package version.
     /// Enabled by default.
     pub git_tag_enable: Option<bool>,
+    /// # Git Tag Name
+    /// The name of the tag. It can be a tera template.
+    pub git_tag_name: Option<String>,
     /// # Publish
     /// If `Some(false)`, don't run `cargo publish`.
     pub publish: Option<bool>,
@@ -256,6 +263,7 @@ impl From<PackageConfig> for release_plz_core::UpdateConfig {
             semver_check: config.semver_check != Some(false),
             changelog_update: config.changelog_update != Some(false),
             release: config.release != Some(false),
+            tag_name: config.git_tag_name,
         }
     }
 }
@@ -284,6 +292,7 @@ impl PackageConfig {
             publish_allow_dirty: self.publish_allow_dirty.or(default.publish_allow_dirty),
             publish_no_verify: self.publish_no_verify.or(default.publish_no_verify),
             git_tag_enable: self.git_tag_enable.or(default.git_tag_enable),
+            git_tag_name: self.git_tag_name.or(default.git_tag_name),
             release: self.release.or(default.release),
         }
     }

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -46,6 +46,7 @@ serde_json.workspace = true
 strip-ansi-escapes.workspace = true
 tokio = { workspace = true, features = ["fs"] }
 http.workspace = true
+tera = "1.19.1"
 
 [dev-dependencies]
 git_cmd = { path = "../git_cmd", features = ["test_fixture"] }

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -79,6 +79,7 @@ the following sections:
   - [`git_release_type`](#the-git_release_type-field-package-section) — Git release type.
   - [`git_release_draft`](#the-git_release_draft-field-package-section) — Publish git release as draft.
   - [`git_tag_enable`](#the-git_tag_enable-field-package-section) — Enable git tag.
+  - [`git_tag_name`](#the-git_tag_name-field) — Customize git tag by Tera template.
   - [`publish`](#the-publish-field-package-section) — Publish to cargo registry.
   - [`publish_allow_dirty`](#the-publish_allow_dirty-field-package-section) — Package dirty directories.
   - [`publish_no_verify`](#the-publish_no_verify-field-package-section) — Don't verify package build.
@@ -200,6 +201,17 @@ Supported values are:
 - If `true`, release-plz creates a git tag for the new package version. *(Default)*.
 - If `false`, release-plz doesn't create a git tag.
   Note: you can't create a git release without a git tag.
+
+#### The `git_tag_name` field
+
+[Tera template](https://keats.github.io/tera/docs/#templates) of the git tags that release-plz creates.
+Use this to customize the git tags name pattern.
+
+By default, it's: "{{ package }}-v{{ version }}" with workspace, or "v{{ version }}" with single project.
+
+Where:
+- `{{ package }}` is the name of the package.
+- `{{ version }}` is the new version of the package.
 
 #### The `pr_draft` field
 
@@ -392,6 +404,10 @@ Overrides the [`workspace.git_release_draft`](#the-git_release_draft-field) fiel
 #### The `git_tag_enable` field (`package` section)
 
 Overrides the [`workspace.git_tag_enable`](#the-git_tag_enable-field) field.
+
+#### The `git_tag_name` field (`package` section)
+
+Overrides the [`workspace.git_tag_name`](#the-git_tag_name-field) field.
 
 #### The `publish` field (`package` section)
 


### PR DESCRIPTION
This PR add custom git tag name feature (https://github.com/MarcoIeni/release-plz/issues/680, https://github.com/MarcoIeni/release-plz/issues/677) :

- setting global by git-tag-name field in workspace
- override in each project by git-tag-name field

Default:

- `{{ package }}-{{ version }}` for workspace 
- `v{{ version }}` for single project 