### PR TITLE
feat: custom git-release-name by tera template. #677

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -42,6 +42,7 @@
         "dependencies_update": null,
         "git_release_draft": null,
         "git_release_enable": null,
+        "git_release_name": null,
         "git_release_type": null,
         "git_tag_enable": null,
         "git_tag_name": null,
@@ -281,6 +282,14 @@
             "null"
           ]
         },
+        "git_release_name": {
+          "title": "Git Release Name",
+          "description": "Tera template of the git release name created by release-plz.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "git_release_type": {
           "title": "Git Release Type",
           "description": "Whether to mark the created release as not ready for production.",
@@ -465,6 +474,14 @@
           "description": "Publish the GitHub/Gitea release for the created git tag. Enabled by default.",
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "git_release_name": {
+          "title": "Git Release Name",
+          "description": "Tera template of the git release name created by release-plz.",
+          "type": [
+            "string",
             "null"
           ]
         },

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -189,6 +189,7 @@ impl From<PackageConfig> for release_plz_core::ReleaseConfig {
             .git_release_type
             .map(|release_type| release_type.into())
             .unwrap_or_default();
+        let git_release_name = value.git_release_name.clone();
         let is_git_tag_enabled = value.git_tag_enable != Some(false);
         let git_tag_name = value.git_tag_name.clone();
         let release = value.release != Some(false);
@@ -197,7 +198,8 @@ impl From<PackageConfig> for release_plz_core::ReleaseConfig {
             .with_git_release(
                 release_plz_core::GitReleaseConfig::enabled(is_git_release_enabled)
                     .set_draft(is_git_release_draft)
-                    .set_release_type(git_release_type),
+                    .set_release_type(git_release_type)
+                    .set_name_template(git_release_name),
             )
             .with_git_tag(
                 release_plz_core::GitTagConfig::enabled(is_git_tag_enabled)
@@ -232,6 +234,9 @@ pub struct PackageConfig {
     /// # Git Release Draft
     /// If true, will not auto-publish the release.
     pub git_release_draft: Option<bool>,
+    /// # Git Release Name
+    /// Tera template of the git release name created by release-plz.
+    pub git_release_name: Option<String>,
     /// # Git Tag Enable
     /// Publish the git tag for the new package version.
     /// Enabled by default.
@@ -264,6 +269,7 @@ impl From<PackageConfig> for release_plz_core::UpdateConfig {
             changelog_update: config.changelog_update != Some(false),
             release: config.release != Some(false),
             tag_name_template: config.git_tag_name,
+            release_name_template: config.git_release_name,
         }
     }
 }
@@ -287,6 +293,7 @@ impl PackageConfig {
             git_release_enable: self.git_release_enable.or(default.git_release_enable),
             git_release_type: self.git_release_type.or(default.git_release_type),
             git_release_draft: self.git_release_draft.or(default.git_release_draft),
+            git_release_name: self.git_release_name.or(default.git_release_name),
 
             publish: self.publish.or(default.publish),
             publish_allow_dirty: self.publish_allow_dirty.or(default.publish_allow_dirty),

--- a/crates/release_plz/tests/all/helpers/gitea/gitea_client.rs
+++ b/crates/release_plz/tests/all/helpers/gitea/gitea_client.rs
@@ -67,6 +67,23 @@ impl GiteaContext {
             .unwrap()
     }
 
+    /// Get the Gitea release associated to the given `tag`.
+    pub async fn get_gitea_release(&self, tag: &str) -> GiteaRelase {
+        let request_path = format!("{}/releases/tags/{}", self.repo_url(), tag);
+        self.client
+            .get(&request_path)
+            .basic_auth(&self.user.username, Some(&self.user.password))
+            .send()
+            .await
+            .unwrap()
+            .ok_if_2xx()
+            .await
+            .unwrap()
+            .json::<GiteaRelase>()
+            .await
+            .unwrap()
+    }
+
     pub async fn get_file_content(&self, branch: &str, file_path: &str) -> String {
         use base64::Engine as _;
         let request_path = format!("{}/contents/{}", self.repo_url(), file_path);
@@ -89,6 +106,11 @@ impl GiteaContext {
             .unwrap();
         String::from_utf8(content).unwrap()
     }
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct GiteaRelase {
+    pub name: String,
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/crates/release_plz/tests/all/release.rs
+++ b/crates/release_plz/tests/all/release.rs
@@ -22,3 +22,25 @@ async fn release_plz_releases_a_new_project_with_custom_tag_name() {
 
     assert!(is_tag_created());
 }
+
+#[tokio::test]
+#[cfg_attr(not(feature = "docker-tests"), ignore)]
+async fn release_plz_releases_a_new_project_with_custom_release_name() {
+    let context = TestContext::new().await;
+
+    let config = r#"
+    [workspace]
+    git_release_name = "{{ package}}--{{ version }}"
+    "#;
+    context.write_release_plz_toml(config);
+
+    let crate_name = &context.gitea.repo;
+
+    let expected_tag = "v0.1.0";
+    let expected_release = format!("{}--0.1.0", crate_name);
+
+    context.run_release().success();
+
+    let gitea_release = context.gitea.get_gitea_release(expected_tag).await;
+    assert_eq!(gitea_release.name, expected_release);
+}

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -192,7 +192,7 @@ impl GitClient {
         let create_release_options = CreateReleaseOption {
             tag_name: &release_info.git_tag,
             body: &release_info.release_body,
-            name: &release_info.git_tag,
+            name: &release_info.release_name,
             draft: &release_info.draft,
             prerelease: &release_info.pre_release,
         };
@@ -208,10 +208,12 @@ impl GitClient {
     pub async fn create_gitlab_release(&self, release_info: &GitReleaseInfo) -> anyhow::Result<()> {
         #[derive(Serialize)]
         pub struct GitlabReleaseOption<'a> {
+            name: &'a str,
             tag_name: &'a str,
             description: &'a str,
         }
         let gitlab_release_options = GitlabReleaseOption {
+            name: &release_info.release_name,
             tag_name: &release_info.git_tag,
             description: &release_info.release_body,
         };

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -516,7 +516,7 @@ impl Project {
             });
 
         tera.add_raw_template("tag_name", tag_template)
-            .expect("failed to add raw template");
+            .expect("failed to add tag_name raw template");
 
         tera.render("tag_name", &context)
             .expect("failed to render tag name")
@@ -538,11 +538,11 @@ impl Project {
                 }
             });
 
-        tera.add_raw_template("tag_name", tag_template)
-            .expect("failed to add raw template");
+        tera.add_raw_template("release_name", tag_template)
+            .expect("failed to add release_name raw template");
 
-        tera.render("tag_name", &context)
-            .expect("failed to render tag name")
+        tera.render("release_name", &context)
+            .expect("failed to render release name")
     }
 
     pub fn cargo_lock_path(&self) -> PathBuf {

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -40,6 +40,8 @@ pub(crate) const NO_COMMIT_ID: &str = "0000000";
 pub struct ReleaseMetadata {
     /// Template for the git tag created by release-plz.
     pub tag_name_template: Option<String>,
+    /// Template for the git release name created by release-plz.
+    pub release_name_template: Option<String>,
 }
 
 pub trait ReleaseMetadataBuilder {
@@ -124,6 +126,8 @@ pub struct UpdateConfig {
     pub release: bool,
     /// Template for the git tag created by release-plz.
     pub tag_name_template: Option<String>,
+    /// Template for the git release name created by release-plz.
+    pub release_name_template: Option<String>,
 }
 
 /// Package-specific config
@@ -158,6 +162,7 @@ impl Default for UpdateConfig {
             changelog_update: true,
             release: true,
             tag_name_template: None,
+            release_name_template: None,
         }
     }
 }
@@ -334,6 +339,7 @@ impl ReleaseMetadataBuilder for UpdateRequest {
         if config.generic.release {
             Some(ReleaseMetadata {
                 tag_name_template: config.generic.tag_name_template.clone(),
+                release_name_template: None,
             })
         } else {
             None
@@ -501,6 +507,29 @@ impl Project {
             .release_metadata
             .get(package_name)
             .and_then(|m| m.tag_name_template.as_deref())
+            .unwrap_or({
+                if self.contains_multiple_pub_packages {
+                    "{{ package }}-v{{ version }}"
+                } else {
+                    "v{{ version }}"
+                }
+            });
+
+        tera.add_raw_template("tag_name", tag_template)
+            .expect("failed to add raw template");
+
+        tera.render("tag_name", &context)
+            .expect("failed to render tag name")
+    }
+
+    pub fn release_name(&self, package_name: &str, version: &str) -> String {
+        let mut tera = tera::Tera::default();
+        let context = tera_context(package_name, version);
+
+        let tag_template = self
+            .release_metadata
+            .get(package_name)
+            .and_then(|m| m.release_name_template.as_deref())
             .unwrap_or({
                 if self.contains_multiple_pub_packages {
                     "{{ package }}-v{{ version }}"
@@ -1192,10 +1221,11 @@ mod tests {
         overrides: HashSet<String>,
         is_release_enabled: bool,
         tag_name: Option<String>,
+        release_name: Option<String>,
     ) -> anyhow::Result<Project> {
         let metadata = get_manifest_metadata(local_manifest).unwrap();
         let release_metadata_builder =
-            ReleaseMetadataBuilderStub::new(is_release_enabled, tag_name);
+            ReleaseMetadataBuilderStub::new(is_release_enabled, tag_name, release_name);
         Project::new(
             local_manifest,
             single_package,
@@ -1208,11 +1238,16 @@ mod tests {
     struct ReleaseMetadataBuilderStub {
         release: bool,
         tag_name: Option<String>,
+        release_name: Option<String>,
     }
 
     impl ReleaseMetadataBuilderStub {
-        pub fn new(release: bool, tag_name: Option<String>) -> Self {
-            Self { release, tag_name }
+        pub fn new(release: bool, tag_name: Option<String>, release_name: Option<String>) -> Self {
+            Self {
+                release,
+                tag_name,
+                release_name,
+            }
         }
     }
 
@@ -1221,6 +1256,7 @@ mod tests {
             if self.release {
                 Some(ReleaseMetadata {
                     tag_name_template: self.tag_name.clone(),
+                    release_name_template: self.release_name.clone(),
                 })
             } else {
                 None
@@ -1242,7 +1278,7 @@ mod tests {
     #[test]
     fn test_empty_override() {
         let local_manifest = Path::new("../../fixtures/typo-in-overrides/Cargo.toml");
-        let result = get_project(local_manifest, None, HashSet::default(), true, None);
+        let result = get_project(local_manifest, None, HashSet::default(), true, None, None);
         assert!(result.is_ok());
     }
 
@@ -1250,7 +1286,7 @@ mod tests {
     fn test_successful_override() {
         let local_manifest = Path::new("../../fixtures/typo-in-overrides/Cargo.toml");
         let overrides = (["typo_test".to_string()]).into();
-        let result = get_project(local_manifest, None, overrides, true, None);
+        let result = get_project(local_manifest, None, overrides, true, None, None);
         assert!(result.is_ok());
     }
 
@@ -1259,7 +1295,7 @@ mod tests {
         let local_manifest = Path::new("../../fixtures/typo-in-overrides/Cargo.toml");
         let single_package = None;
         let overrides = vec!["typo_tesst".to_string()].into_iter().collect();
-        let result = get_project(local_manifest, single_package, overrides, true, None);
+        let result = get_project(local_manifest, single_package, overrides, true, None, None);
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().to_string(),
@@ -1299,7 +1335,7 @@ mod tests {
     #[test]
     fn project_new_no_release_will_error() {
         let local_manifest = Path::new("../fake_package/Cargo.toml");
-        let result = get_project(local_manifest, None, HashSet::default(), false, None);
+        let result = get_project(local_manifest, None, HashSet::default(), false, None, None);
         assert!(result.is_err());
         expect_test::expect![[r#"no public packages found. Are there any public packages in your project? Analyzed packages: ["cargo_utils", "fake_package", "git_cmd", "test_logs", "next_version", "release-plz", "release_plz_core"]"#]]
         .assert_eq(&result.unwrap_err().to_string());
@@ -1308,13 +1344,13 @@ mod tests {
     #[test]
     fn project_tag_template_none() {
         let local_manifest = Path::new("../../fixtures/typo-in-overrides/Cargo.toml");
-        let project =
-            get_project(local_manifest, None, HashSet::default(), true, None).expect("Should ok");
+        let project = get_project(local_manifest, None, HashSet::default(), true, None, None)
+            .expect("Should ok");
         assert_eq!(project.git_tag("typo_test", "0.1.0"), "v0.1.0");
     }
 
     #[test]
-    fn project_tag_template_some() {
+    fn project_release_and_tag_template_some() {
         let local_manifest = Path::new("../../fixtures/typo-in-overrides/Cargo.toml");
         let project = get_project(
             local_manifest,
@@ -1322,11 +1358,16 @@ mod tests {
             HashSet::default(),
             true,
             Some("prefix-{{ package }}-middle-{{ version }}-postfix".to_string()),
+            Some("release-prefix-{{ package }}-middle-{{ version }}-postfix".to_string()),
         )
         .expect("Should ok");
         assert_eq!(
             project.git_tag("typo_test", "0.1.0"),
             "prefix-typo_test-middle-0.1.0-postfix"
+        );
+        assert_eq!(
+            project.release_name("typo_test", "0.1.0"),
+            "release-prefix-typo_test-middle-0.1.0-postfix"
         );
     }
 }

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -58,6 +58,7 @@ the following sections:
   - [`changelog_update`](#the-changelog_update-field) — Update changelog.
   - [`dependencies_update`](#the-dependencies_update-field) — Update all dependencies.
   - [`git_release_enable`](#the-git_release_enable-field) — Enable git release.
+  - [`git_release_name`](#the-git_release_name-field) — Customize git release name pattern.
   - [`git_release_type`](#the-git_release_type-field) — Publish mode for git release.
   - [`git_release_draft`](#the-git_release_draft-field) — Publish git release as draft.
   - [`git_tag_enable`](#the-git_tag_enable-field) — Enable git tag.
@@ -77,6 +78,7 @@ the following sections:
   - [`changelog_path`](#the-changelog_path-field-package-section) — Changelog path.
   - [`changelog_update`](#the-changelog_update-field-package-section) — Update changelog.
   - [`git_release_enable`](#the-git_release_enable-field-package-section) — Enable git release.
+  - [`git_release_name`](#the-git_release_name-field-package-section) — Customize git release name pattern.
   - [`git_release_type`](#the-git_release_type-field-package-section) — Git release type.
   - [`git_release_draft`](#the-git_release_draft-field-package-section) — Publish git release as draft.
   - [`git_tag_enable`](#the-git_tag_enable-field-package-section) — Enable git tag.
@@ -174,6 +176,22 @@ The supported git releases are:
 - [GitHub](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
 - [Gitea](https://docs.gitea.io/en-us/)
 - [GitLab](https://docs.gitlab.com/ee/user/project/releases/#releases)
+
+#### The `git_release_name` field
+
+[Tera template](https://keats.github.io/tera/docs/#templates) of the git release name that release-plz creates.
+Use this to customize the git release name pattern.
+
+By default, it's:
+
+- `"{{ package }}-v{{ version }}"` for workspaces containing more than one public package.
+- `"v{{ version }}"` for projects containing a single crate or
+  workspaces containing just one public package.
+
+Where:
+
+- `{{ package }}` is the name of the package.
+- `{{ version }}` is the new version of the package.
 
 #### The `git_release_type` field
 
@@ -398,6 +416,10 @@ This field cannot be set in the `[workspace]` section.
 #### The `git_release_enable` field (`package` section)
 
 Overrides the [`workspace.git_release_enable`](#the-git_release_enable-field) field.
+
+#### The `git_release_name` field (`package` section)
+
+Overrides the [`workspace.git_release_name`](#the-git_release_name-field) field.
 
 #### The `git_release_type` field (`package` section)
 


### PR DESCRIPTION
This PR add custom git release name feature (https://github.com/MarcoIeni/release-plz/issues/677) :

- setting global by git-release-name field in workspace
- override in each project by git-release-name field

Default:

- `{{ package }}-{{ version }}` for workspace 
- `v{{ version }}` for single project 

Ps: Only Project.release_name is tested, maybe we need some way to test it but I don'f familiar with GitTea for adding more tests.