### PR TITLE
chore: avoid `git checkout` when visiting git history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ dependencies = [
  "ignore",
  "im-rc",
  "indexmap",
- "itertools",
+ "itertools 0.11.0",
  "jobserver",
  "lazycell",
  "libc",
@@ -1439,6 +1439,7 @@ version = "0.4.20"
 dependencies = [
  "anyhow",
  "git_cmd",
+ "itertools 0.12.1",
  "tempfile",
  "test_logs",
  "tracing",
@@ -3143,6 +3144,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ git-cliff-core = { version = "1.4.0", default-features = false }
 git-url-parse = "0.4.4"
 http = "0.2.11"
 ignore = "0.4.22"
+itertools = "0.12.1"
 lazy_static = "1.4.0"
 once_cell = "1.19.0"
 parse-changelog = { version = "0.6.4", default-features = false }

--- a/crates/git_cmd/Cargo.toml
+++ b/crates/git_cmd/Cargo.toml
@@ -19,6 +19,7 @@ test_fixture = []
 [dependencies]
 anyhow.workspace = true
 tracing.workspace = true
+itertools.workspace = true
 
 [dev-dependencies]
 git_cmd = { path = ".", features = ["test_fixture"]}

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -140,12 +140,6 @@ impl Repo {
         Ok(())
     }
 
-    #[instrument(skip(self))]
-    pub fn checkout_head(&self) -> anyhow::Result<()> {
-        self.checkout(&self.original_branch)?;
-        Ok(())
-    }
-
     /// Branch name before running any git operation.
     /// I.e. when the [`Repo`] was created.
     pub fn original_branch(&self) -> &str {

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -246,9 +246,9 @@ impl Repo {
         let separator = "@@git-cmd-separator@@";
         let pretty_format = format!("--pretty=format:%H{separator}%B{separator}");
         let (skip, n) = if most_recent_hash.is_some() {
-            (1, n)
+            (1, n + 1)
         } else {
-            (0, n + 1)
+            (0, n)
         };
         let n = n.to_string();
         let args = {

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -235,11 +235,10 @@ impl Repo {
     pub fn get_last_n_commits(
         &self,
         n: usize,
-        most_recent_hash: Option<&str>,
+        most_recent_hash: &str,
         directory: &Path,
     ) -> anyhow::Result<Vec<GitCommit>> {
         let separator = "@@git-cmd-separator@@";
-        let most_recent_hash = most_recent_hash.unwrap_or("");
         let pretty_format = format!("--pretty=format:%H{separator}%B{separator}");
         let commit_output = self.git(&[
             "log",

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -184,13 +184,6 @@ impl Repo {
         Ok(())
     }
 
-    /// Checkout to the latest commit.
-    pub fn checkout_last_commit_at_path(&self, path: &Path) -> anyhow::Result<()> {
-        let previous_commit = self.last_commit_at_path(path)?;
-        self.checkout(&previous_commit)?;
-        Ok(())
-    }
-
     fn last_commit_at_path(&self, path: &Path) -> anyhow::Result<String> {
         self.nth_commit_at_path(1, path)
     }

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -231,13 +231,16 @@ impl Repo {
         Ok(last_commit.to_string())
     }
 
-    /// Retrieve the last `n` commits.
+    /// Retrieve the last `n` commits in the `path`.
     pub fn get_last_n_commits(
         &self,
         n: usize,
         most_recent_hash: &str,
-        directory: &Path,
+        path: &Path,
     ) -> anyhow::Result<Vec<GitCommit>> {
+        let path: &str = path
+            .to_str()
+            .ok_or_else(|| anyhow!("invalid path {path:?}"))?;
         let separator = "@@git-cmd-separator@@";
         let pretty_format = format!("--pretty=format:%H{separator}%B{separator}");
         let commit_output = self.git(&[
@@ -247,7 +250,7 @@ impl Repo {
             &format!("{n}"),
             most_recent_hash,
             "--",
-            &format!("{directory:?}"),
+            path,
         ])?;
         commit_output
             .split(separator)
@@ -435,7 +438,7 @@ mod tests {
         }
         let current_hash = repo.current_commit_hash().unwrap();
         let commits = repo
-            .get_last_n_commits(3, &current_hash, repository_dir.as_ref())
+            .get_last_n_commits(1, &current_hash, repository_dir.as_ref())
             .unwrap();
         assert_eq!(commit_message, commits[0].message);
     }

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -417,6 +417,30 @@ mod tests {
     }
 
     #[test]
+    fn last_commit_is_retrieved() {
+        test_logs::init();
+        let repository_dir = tempdir().unwrap();
+        let repo = Repo::init(&repository_dir);
+        let file1 = repository_dir.as_ref().join("file1.txt");
+
+        let commit_message = r#"feat: my feature
+
+        message
+
+        footer: small note"#;
+
+        {
+            fs::write(file1, b"Hello, file1!").unwrap();
+            repo.add_all_and_commit(commit_message).unwrap();
+        }
+        let current_hash = repo.current_commit_hash().unwrap();
+        let commits = repo
+            .get_last_n_commits(3, &current_hash, repository_dir.as_ref())
+            .unwrap();
+        assert_eq!(commit_message, commits[0].message);
+    }
+
+    #[test]
     fn current_commit_is_retrieved() {
         test_logs::init();
         let repository_dir = tempdir().unwrap();

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -446,9 +446,8 @@ mod tests {
             fs::write(file1, b"Hello, file1!").unwrap();
             repo.add_all_and_commit(commit_message).unwrap();
         }
-        let current_hash = repo.current_commit_hash().unwrap();
         let commits = repo
-            .get_last_n_commits(1, Some(&current_hash), repository_dir.as_ref())
+            .get_last_n_commits(1, None, repository_dir.as_ref())
             .unwrap();
         assert_eq!(commit_message, commits[0].message);
     }

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -245,6 +245,11 @@ impl Repo {
             .ok_or_else(|| anyhow!("invalid path {path:?}"))?;
         let separator = "@@git-cmd-separator@@";
         let pretty_format = format!("--pretty=format:%H{separator}%B{separator}");
+        let (skip, n) = if most_recent_hash.is_some() {
+            (1, n)
+        } else {
+            (0, n + 1)
+        };
         let n = n.to_string();
         let args = {
             let mut args = vec!["log", &pretty_format, "-n", &n];
@@ -255,7 +260,6 @@ impl Repo {
             args.push(path);
             args
         };
-        let skip = if most_recent_hash.is_some() { 1 } else { 0 };
         let commit_output = self.git(&args)?;
         commit_output
             .split(separator)

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -908,6 +908,8 @@ impl Updater<'_> {
     ) -> anyhow::Result<()> {
         let mut latest_hash: Option<String> = None;
         'outer: loop {
+            // Reading 10 commits at a time, starting from the latest commit.
+            // We batch the commits for performance reasons: to avoid spawning too many git processes.
             let last_10_commits =
                 repository.get_last_n_commits(10, latest_hash.as_deref(), package_path)?;
             if last_10_commits.is_empty() {

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -892,9 +892,6 @@ impl Updater<'_> {
             tag_commit,
             &mut diff,
         )?;
-        repository
-            .checkout_head()
-            .context("can't checkout to head after calculating diff")?;
         Ok(diff)
     }
 
@@ -984,10 +981,6 @@ impl Updater<'_> {
                     current_commit_hash,
                     current_commit_message.clone(),
                 ));
-            }
-            if let Err(_err) = repository.checkout_previous_commit_at_path(package_path) {
-                debug!("there are no other commits");
-                break;
             }
         }
         Ok(())

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -906,17 +906,18 @@ impl Updater<'_> {
         tag_commit: Option<String>,
         diff: &mut Diff,
     ) -> anyhow::Result<()> {
-        let mut latest_hash: String = repository.current_commit_hash()?;
+        let mut latest_hash: Option<String> = None;
         'outer: loop {
             // Reading 10 commits at a time, starting from the latest commit.
             // We batch the commits for performance reasons: to avoid spawning too many git processes.
-            let last_10_commits = repository.get_last_n_commits(10, &latest_hash, package_path)?;
+            let last_10_commits =
+                repository.get_last_n_commits(10, latest_hash.as_deref(), package_path)?;
             if last_10_commits.is_empty() {
                 info!("{}: there are no commits", package.name);
                 break;
             }
             for current_commit in last_10_commits {
-                latest_hash = current_commit.hash.clone();
+                latest_hash = Some(current_commit.hash.clone());
                 if let Some(registry_package) = registry_package {
                     debug!("package {} found in cargo registry", registry_package.name);
                     let registry_package_path = registry_package.package_path()?;

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -870,9 +870,6 @@ impl Updater<'_> {
         let package_path = get_package_path(package, repository, &self.project.root)
             .context("failed to determine package path")?;
 
-        repository
-            .checkout_head()
-            .context("can't checkout head to calculate diff")?;
         let registry_package = registry_packages.get_package(&package.name);
         let mut diff = Diff::new(registry_package.is_some());
         if let Err(err) = repository.checkout_last_commit_at_path(&package_path) {
@@ -982,9 +979,6 @@ impl Updater<'_> {
                 break;
             }
         }
-        repository
-            .checkout_head()
-            .context("can't checkout to head after calculating diff")?;
         Ok(diff)
     }
 

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -856,7 +856,6 @@ impl Updater<'_> {
         })
     }
 
-    /// This operation is not thread-safe, because we do `git checkout` on the repository.
     #[instrument(
         skip_all,
         fields(package = %package.name)
@@ -872,17 +871,6 @@ impl Updater<'_> {
 
         let registry_package = registry_packages.get_package(&package.name);
         let mut diff = Diff::new(registry_package.is_some());
-        if let Err(err) = repository.checkout_last_commit_at_path(&package_path) {
-            if err
-                .to_string()
-                .contains("Your local changes to the following files would be overwritten")
-            {
-                return Err(err.context("The allow-dirty option can't be used in this case"));
-            } else {
-                info!("{}: there are no commits", package.name);
-                return Ok(diff);
-            }
-        }
 
         let git_tag = self
             .project

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -906,18 +906,17 @@ impl Updater<'_> {
         tag_commit: Option<String>,
         diff: &mut Diff,
     ) -> anyhow::Result<()> {
-        let mut latest_hash: Option<String> = None;
+        let mut latest_hash: String = repository.current_commit_hash()?;
         'outer: loop {
             // Reading 10 commits at a time, starting from the latest commit.
             // We batch the commits for performance reasons: to avoid spawning too many git processes.
-            let last_10_commits =
-                repository.get_last_n_commits(10, latest_hash.as_deref(), package_path)?;
+            let last_10_commits = repository.get_last_n_commits(10, &latest_hash, package_path)?;
             if last_10_commits.is_empty() {
                 info!("{}: there are no commits", package.name);
                 break;
             }
             for current_commit in last_10_commits {
-                latest_hash = Some(current_commit.hash.clone());
+                latest_hash = current_commit.hash.clone();
                 if let Some(registry_package) = registry_package {
                     debug!("package {} found in cargo registry", registry_package.name);
                     let registry_package_path = registry_package.package_path()?;

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -856,6 +856,8 @@ impl Updater<'_> {
         })
     }
 
+    /// This operation is not thread-safe, because we do `git checkout Cargo.lock`
+    /// to revert `Cargo.lock` after we run `cargo package`.
     #[instrument(
         skip_all,
         fields(package = %package.name)


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
We can retrieve all logs at once with `git log -10 --pretty=format:///%B///%H/// -- /path/to/crate`
with this approach we can retrieve git commits in batches (in this example of 10).
We don't need to do `git checkout`.
`///` is a separator. We can use something more specific, such as `@@release@plz@@` to avoid conflicts with git commit messages.

With this, we don't need to copy to a temporary directory when doing `release-plz update`.

- [x] check git history of crates in parallel? Answer: not possible for now