### PR TITLE
docs: remove left-over raw string literals

### DIFF
--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -537,7 +537,7 @@ body = """
 - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}
 {% endif -%}
 {% endfor -%}
-{% endfor %}"#;
+{% endfor %}
 """
 ```
 


### PR DESCRIPTION
Tiny fix.