### PR TITLE
fix: an issue with modified files due to lfs

### DIFF
--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -213,7 +213,7 @@ impl Repo {
 
     #[instrument(skip(self))]
     pub fn checkout(&self, object: &str) -> anyhow::Result<()> {
-        self.git(&["checkout", object])?;
+        self.git(&["checkout", "-f", object])?;
         Ok(())
     }
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
This is an attempt to fix #1186 . 

I haven't quite figured out the exact issue but it appears that when looking for commits with `get_package_diff` the repository is left in a modified state due to some weird interaction with `lfs` files being moved from- or into `git lfs` that previously weren't or shouldn't. Im not entirely sure. 

Anyway, the "fix" that I implemented is to "force" the checkout of a certain commit by adding '-f' to the arguments of `git checkout`. This fixes the issue that occurs in #1186 but I cant fully comprehend if this has some negative consequences for other parts the execution. Feedback is very welcome.