### PR TITLE
chore(ci): remove support for universal mac app

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-12
           - target: x86_64-pc-windows-msvc
             os: windows-2022
           - target: x86_64-unknown-linux-musl
@@ -44,11 +44,9 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-22.04
           - target: aarch64-apple-darwin
-            os: macos-13
+            os: macos-12
           - target: x86_64-unknown-freebsd
             os: ubuntu-22.04
-          - target: universal-apple-darwin
-            os: macos-13
     timeout-minutes: 60
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,11 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-12
           - target: x86_64-pc-windows-msvc
             os: windows-2022
-          - target: universal-apple-darwin
-            os: macos-13
+          - target: x86_64-apple-darwin
+            os: macos-12
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/website/docs/extra/releasing-binaries.md
+++ b/website/docs/extra/releasing-binaries.md
@@ -65,7 +65,7 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-22.04
           - target: aarch64-apple-darwin
-            os: macos-13
+            os: macos-12
           - target: aarch64-pc-windows-msvc
             os: windows-2022
           - target: x86_64-unknown-linux-gnu
@@ -73,13 +73,11 @@ jobs:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-22.04
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-12
           - target: x86_64-pc-windows-msvc
             os: windows-2022
           - target: x86_64-unknown-freebsd
             os: ubuntu-22.04
-          - target: universal-apple-darwin
-            os: macos-13
     timeout-minutes: 60
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
openssl doesn't compile