### PR TITLE
fix: check diffs in README

### DIFF
--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -229,7 +229,8 @@ impl Repo {
         let git_args = {
             let mut git_args = vec!["log", "--format=%H", "-n", &nth_str, "--"];
             for p in paths {
-                git_args.push(p.to_str().expect("invalid path"));
+                let path = p.to_str().expect("invalid path");
+                git_args.push(path);
             }
             git_args
         };

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -2,7 +2,7 @@ use crate::{
     changelog_parser::{self, ChangelogRelease},
     copy_dir::copy_dir,
     diff::Diff,
-    lock_compare,
+    is_readme_updated, lock_compare,
     package_compare::are_packages_equal,
     package_path::{manifest_dir, PackagePath},
     registry_packages::{self, PackagesCollection},
@@ -954,8 +954,12 @@ impl Updater<'_> {
                 debug!("package {} found in cargo registry", registry_package.name);
                 let registry_package_path = registry_package.package_path()?;
 
-                let are_packages_equal =
-                    self.check_package_equality(repository, package_path, registry_package_path)?;
+                let are_packages_equal = self.check_package_equality(
+                    repository,
+                    package,
+                    package_path,
+                    registry_package_path,
+                )?;
                 if are_packages_equal
                     || is_commit_too_old(repository, tag_commit.as_deref(), &current_commit_hash)
                 {
@@ -1003,9 +1007,13 @@ impl Updater<'_> {
     fn check_package_equality(
         &self,
         repository: &Repo,
+        package: &Package,
         package_path: &Path,
         registry_package_path: &Path,
     ) -> anyhow::Result<bool> {
+        if is_readme_updated(package_path, package, registry_package_path)? {
+            return Ok(false);
+        }
         // We run `cargo package` when comparing packages, which can edit files, such as `Cargo.lock`.
         // Store its path so it can be reverted after comparison.
         let cargo_lock_path = self

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -1012,6 +1012,7 @@ impl Updater<'_> {
         registry_package_path: &Path,
     ) -> anyhow::Result<bool> {
         if is_readme_updated(package_path, package, registry_package_path)? {
+            debug!("{}: README updated", package.name);
             return Ok(false);
         }
         // We run `cargo package` when comparing packages, which can edit files, such as `Cargo.lock`.

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -1180,7 +1180,7 @@ fn is_commit_too_old(
 
 fn pathbufs_to_check(package_path: &Path, package: &Package) -> Vec<PathBuf> {
     let mut paths = vec![package_path.to_path_buf()];
-    if let Some(readme_path) = local_readme_override(package, &package_path) {
+    if let Some(readme_path) = local_readme_override(package, package_path) {
         paths.push(readme_path);
     }
     paths

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -147,7 +147,7 @@ pub fn is_readme_updated(
         }
         None => true,
     };
-    Ok(are_readmes_equal)
+    Ok(!are_readmes_equal)
 }
 
 fn are_files_equal(first: &Path, second: &Path) -> anyhow::Result<bool> {

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -123,7 +123,10 @@ fn are_cargo_toml_equal(local_package: &Path, registry_package: &Path) -> bool {
 }
 
 /// Returns true if the README file of the local package is the same as the one in the registry.
-/// Returns false if the README is the same or if the local package doesn't have a `readme` field in the `Cargo.toml`.
+/// Returns false if:
+/// - the README is the same
+/// - the local package doesn't have a `readme` field in the `Cargo.toml`.
+/// - the package doesn't have a README at all.
 pub fn is_readme_updated(
     local_package_path: &Path,
     package: &Package,
@@ -136,6 +139,9 @@ pub fn is_readme_updated(
     let are_readmes_equal = match local_package_readme_path {
         Some(local_package_readme_path) => {
             let registry_package_readme_path = registry_package_path.join("README.md");
+            if !registry_package_readme_path.exists() {
+                return Ok(true);
+            }
             are_files_equal(&local_package_readme_path, &registry_package_readme_path)
                 .context("cannot compare README files")?
         }

--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -9,7 +9,7 @@ use std::{
     fs::File,
     hash::{Hash, Hasher},
     io::{self, Read},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 /// Check if two packages are equal.
@@ -132,10 +132,7 @@ pub fn is_readme_updated(
     package: &Package,
     registry_package_path: &Path,
 ) -> anyhow::Result<bool> {
-    let local_package_readme_path = package
-        .readme
-        .as_ref()
-        .map(|readme| local_package_path.join(readme));
+    let local_package_readme_path = local_readme_override(package, local_package_path);
     let are_readmes_equal = match local_package_readme_path {
         Some(local_package_readme_path) => {
             let registry_package_readme_path = registry_package_path.join("README.md");
@@ -148,6 +145,13 @@ pub fn is_readme_updated(
         None => true,
     };
     Ok(!are_readmes_equal)
+}
+
+pub fn local_readme_override(package: &Package, local_package_path: &Path) -> Option<PathBuf> {
+    package
+        .readme
+        .as_ref()
+        .map(|readme| local_package_path.join(readme))
 }
 
 fn are_files_equal(first: &Path, second: &Path) -> anyhow::Result<bool> {


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
Close https://github.com/MarcoIeni/release-plz/issues/1309

ISSUE:
- [x] [here](https://github.com/MarcoIeni/release-plz/blob/6c716cca439230dbbb2cc8f67cb57c764947d5ff/crates/git_cmd/src/lib.rs#L242) we do `git checkout` to the commit in the path. However the README is not in that path, because it's in the root directory. Maybe we should:
  - `git checkout` to the commits of the readme
  - compare the changes
  - add the commit if they differ and if the commit isn't present yet.

- [x] alternative approach (easier): when doing a comparison, simply compare the readme of the registry with the readme of the package path. Similar to how we do for cargo.toml, we should compare the readmes individually and filter the readme out probably (if a readme if specified in Cargo.toml).