### PR TITLE
fix: Fix starting containers with podman

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # We use Gitea as a git server.
   # We test that release-plz can open PRs, create releases, etc.
   gitea:
-    image: gitea/gitea:1.21.6-rootless
+    image: docker.io/gitea/gitea:1.21.6-rootless
     container_name: gitea
     restart: always
     environment:
@@ -27,7 +27,7 @@ services:
   # We use postgres as a database for Gitea.
   # With SqlLite I had problems related to database locks.
   db:
-    image: postgres:16
+    image: docker.io/library/postgres:16
     restart: always
     environment:
       - POSTGRES_USER=gitea


### PR DESCRIPTION
This partially fixes issue #1318 (containers can now be started with podman, but the actual tests still don't pass for unknown reason).