### PR TITLE
feat: Add `publish_features` to pass feature list to `cargo publish`

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -50,6 +50,7 @@
         "pr_labels": [],
         "publish": null,
         "publish_allow_dirty": null,
+        "publish_features": null,
         "publish_no_verify": null,
         "publish_timeout": null,
         "release": null,
@@ -339,6 +340,17 @@
             "null"
           ]
         },
+        "publish_features": {
+          "title": "Publish Features",
+          "description": "If `Some(vec![\"a\", \"b\", \"c\"])`, add the `--features=a,b,c` flag to the `cargo publish` command.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "publish_no_verify": {
           "title": "Publish No Verify",
           "description": "If `Some(true)`, add the `--no-verify` flag to the `cargo publish` command.",
@@ -545,6 +557,17 @@
             "boolean",
             "null"
           ]
+        },
+        "publish_features": {
+          "title": "Publish Features",
+          "description": "If `Some(vec![\"a\", \"b\", \"c\"])`, add the `--features=a,b,c` flag to the `cargo publish` command.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         },
         "publish_no_verify": {
           "title": "Publish No Verify",

--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -326,7 +326,7 @@
         },
         "publish": {
           "title": "Publish",
-          "description": "If `Some(false)`, don't run `cargo publish`.",
+          "description": "If `false`, don't run `cargo publish`.",
           "type": [
             "boolean",
             "null"
@@ -334,7 +334,7 @@
         },
         "publish_allow_dirty": {
           "title": "Publish Allow Dirty",
-          "description": "If `Some(true)`, add the `--allow-dirty` flag to the `cargo publish` command.",
+          "description": "If `true`, add the `--allow-dirty` flag to the `cargo publish` command.",
           "type": [
             "boolean",
             "null"
@@ -342,7 +342,7 @@
         },
         "publish_features": {
           "title": "Publish Features",
-          "description": "If `Some(vec![\"a\", \"b\", \"c\"])`, add the `--features=a,b,c` flag to the `cargo publish` command.",
+          "description": "If `[\"a\", \"b\", \"c\"]`, add the `--features=a,b,c` flag to the `cargo publish` command.",
           "type": [
             "array",
             "null"
@@ -353,7 +353,7 @@
         },
         "publish_no_verify": {
           "title": "Publish No Verify",
-          "description": "If `Some(true)`, add the `--no-verify` flag to the `cargo publish` command.",
+          "description": "If `true`, add the `--no-verify` flag to the `cargo publish` command.",
           "type": [
             "boolean",
             "null"
@@ -544,7 +544,7 @@
         },
         "publish": {
           "title": "Publish",
-          "description": "If `Some(false)`, don't run `cargo publish`.",
+          "description": "If `false`, don't run `cargo publish`.",
           "type": [
             "boolean",
             "null"
@@ -552,7 +552,7 @@
         },
         "publish_allow_dirty": {
           "title": "Publish Allow Dirty",
-          "description": "If `Some(true)`, add the `--allow-dirty` flag to the `cargo publish` command.",
+          "description": "If `true`, add the `--allow-dirty` flag to the `cargo publish` command.",
           "type": [
             "boolean",
             "null"
@@ -560,7 +560,7 @@
         },
         "publish_features": {
           "title": "Publish Features",
-          "description": "If `Some(vec![\"a\", \"b\", \"c\"])`, add the `--features=a,b,c` flag to the `cargo publish` command.",
+          "description": "If `[\"a\", \"b\", \"c\"]`, add the `--features=a,b,c` flag to the `cargo publish` command.",
           "type": [
             "array",
             "null"
@@ -571,7 +571,7 @@
         },
         "publish_no_verify": {
           "title": "Publish No Verify",
-          "description": "If `Some(true)`, add the `--no-verify` flag to the `cargo publish` command.",
+          "description": "If `true`, add the `--no-verify` flag to the `cargo publish` command.",
           "type": [
             "boolean",
             "null"

--- a/crates/release_plz/src/args/release.rs
+++ b/crates/release_plz/src/args/release.rs
@@ -171,6 +171,7 @@ mod tests {
             [[package]]
             name = "aaa"
             publish_allow_dirty = true
+            publish_features = ["a", "b", "c"]
         "#;
 
         let release_args = default_args();
@@ -180,6 +181,7 @@ mod tests {
             .unwrap();
         assert!(actual_request.allow_dirty("aaa"));
         assert!(actual_request.no_verify("aaa"));
+        assert_eq!(actual_request.features("aaa"), &["a", "b", "c"]);
     }
 
     fn default_args() -> Release {

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -215,6 +215,9 @@ impl From<PackageConfig> for release_plz_core::ReleaseConfig {
         if let Some(no_verify) = value.publish_no_verify {
             cfg = cfg.with_no_verify(no_verify);
         }
+        if let Some(features) = value.publish_features {
+            cfg = cfg.with_features(features);
+        }
         if let Some(allow_dirty) = value.publish_allow_dirty {
             cfg = cfg.with_allow_dirty(allow_dirty);
         }
@@ -258,6 +261,9 @@ pub struct PackageConfig {
     /// # Publish No Verify
     /// If `Some(true)`, add the `--no-verify` flag to the `cargo publish` command.
     pub publish_no_verify: Option<bool>,
+    /// # Publish Features
+    /// If `Some(vec!["a", "b", "c"])`, add the `--features=a,b,c` flag to the `cargo publish` command.
+    pub publish_features: Option<Vec<String>>,
     /// # Semver Check
     /// Controls when to run cargo-semver-checks.
     /// If unspecified, run cargo-semver-checks if the package is a library.
@@ -303,6 +309,7 @@ impl PackageConfig {
             publish: self.publish.or(default.publish),
             publish_allow_dirty: self.publish_allow_dirty.or(default.publish_allow_dirty),
             publish_no_verify: self.publish_no_verify.or(default.publish_no_verify),
+            publish_features: self.publish_features.or(default.publish_features),
             git_tag_enable: self.git_tag_enable.or(default.git_tag_enable),
             git_tag_name: self.git_tag_name.or(default.git_tag_name),
             release: self.release.or(default.release),

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -253,16 +253,16 @@ pub struct PackageConfig {
     /// Tera template of the git tag name created by release-plz.
     pub git_tag_name: Option<String>,
     /// # Publish
-    /// If `Some(false)`, don't run `cargo publish`.
+    /// If `false`, don't run `cargo publish`.
     pub publish: Option<bool>,
     /// # Publish Allow Dirty
-    /// If `Some(true)`, add the `--allow-dirty` flag to the `cargo publish` command.
+    /// If `true`, add the `--allow-dirty` flag to the `cargo publish` command.
     pub publish_allow_dirty: Option<bool>,
     /// # Publish No Verify
-    /// If `Some(true)`, add the `--no-verify` flag to the `cargo publish` command.
+    /// If `true`, add the `--no-verify` flag to the `cargo publish` command.
     pub publish_no_verify: Option<bool>,
     /// # Publish Features
-    /// If `Some(vec!["a", "b", "c"])`, add the `--features=a,b,c` flag to the `cargo publish` command.
+    /// If `["a", "b", "c"]`, add the `--features=a,b,c` flag to the `cargo publish` command.
     pub publish_features: Option<Vec<String>>,
     /// # Semver Check
     /// Controls when to run cargo-semver-checks.

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -39,6 +39,7 @@ publish = false # disable `cargo publish` for `package_a`
 name = "package_b"
 semver_check = true # enable semver_check for `package_b`
 publish_no_verify = true # add `--no-verify` to `cargo publish` for `package_b`
+publish_features = ["a", "b"] # add `--features=a,b` to `cargo publish` for `package_b`
 
 [[package]]
 name = "package_c"
@@ -69,6 +70,7 @@ the following sections:
   - [`publish`](#the-publish-field) — Publish to cargo registry.
   - [`publish_allow_dirty`](#the-publish_allow_dirty-field) — Package dirty directories.
   - [`publish_no_verify`](#the-publish_no_verify-field) — Don't verify package build.
+  - [`publish_features`](#the-publish_features-field) — List of features to pass to `cargo publish`.
   - [`publish_timeout`](#the-publish_timeout-field) — `cargo publish` timeout.
   - [`release`](#the-release-field) - Enable the processing of the packages.
   - [`release_commits`](#the-release_commits-field) - Customize which commits trigger a release.
@@ -88,6 +90,7 @@ the following sections:
   - [`publish`](#the-publish-field-package-section) — Publish to cargo registry.
   - [`publish_allow_dirty`](#the-publish_allow_dirty-field-package-section) — Package dirty directories.
   - [`publish_no_verify`](#the-publish_no_verify-field-package-section) — Don't verify package build.
+  - [`publish_features`](#the-publish_features-field-package-section) — List of features to pass to `cargo publish`.
   - [`release`](#the-release-field-package-section) - Enable the processing of this package.
   - [`semver_check`](#the-semver_check-field-package-section) — Run [cargo-semver-checks].
     Don't verify package build.
@@ -284,6 +287,14 @@ Don't verify the contents by building them.
 - If `true`, `release-plz` adds the `--no-verify` flag to `cargo publish`.
 - If `false`, `cargo publish` fails if your repository doesn't build. *(Default)*.
 
+### The `publish_features` field
+
+Pass a list of features to use for verification by `cargo publish`.
+
+- If set to a list of features (e.g. `["a", "b"]`), `release-plz` adds `--features=a,b` flag to
+  `cargo publish`.
+- If not set or if it is empty, no list of features will be passed to `cargo publish`.
+
 #### The `publish_timeout` field
 
 The timeout used when:
@@ -470,6 +481,10 @@ Overrides the
 #### The `publish_no_verify` field (`package` section)
 
 Overrides the [`workspace.publish_no_verify`](#the-publish_no_verify-field) field.
+
+### The `publish_features` field (`package` section)
+
+Overrides the [`workspace.publish_features`](#the-publish_features-field) field.
 
 #### The `release` field (`package` section)
 


### PR DESCRIPTION
feat: Add `publish_features` to pass feature list to `cargo publish`

This implements issue #1308

This is useful to avoid having to use `publish_no_verify` for packages that need at least some features enabled.

I believe the changes are relatively straightforward. I cannot properly test this due to issue #1318  though. I also didn't see any end-to-end tests for the existing `publish_no_verify` so that hasn't been added. I just added the equivalent tests of `publish_no_verify` that I could find.