### PR TITLE
chore: emit a warning on readme file mismatch

### DIFF
--- a/crates/release_plz_core/src/package_compare.rs
+++ b/crates/release_plz_core/src/package_compare.rs
@@ -144,8 +144,12 @@ pub fn is_readme_updated(
             if !registry_package_readme_path.exists() {
                 return Ok(true);
             }
-            are_files_equal(&local_package_readme_path, &registry_package_readme_path)
-                .context("cannot compare README files")?
+            if let Err(e) =
+                are_files_equal(&local_package_readme_path, &registry_package_readme_path)
+            {
+                tracing::warn!("cannot compare README files: {e}");
+            }
+            true
         }
         None => true,
     };


### PR DESCRIPTION
See #1360

> Possible solutions:
>
> - return true if `cannot compare README files` and emit a warning. Probably this is the best short-term solution,
