### PR TITLE
docs: fix the single git tag config example

### DIFF
--- a/website/docs/extra/single-tag.md
+++ b/website/docs/extra/single-tag.md
@@ -17,7 +17,7 @@ git_tag_enable = false
 [[package]]
 name = "my_main_package"
 # (Optional) Customize the git tag name to remove the `my_main_package` prefix.
-git_tag_name = "v{{version}}"
+git_tag_name = "v{{ version }}"
 
 # Enable git tags for this package
 git_tag_enable = true

--- a/website/docs/extra/single-tag.md
+++ b/website/docs/extra/single-tag.md
@@ -17,7 +17,7 @@ git_tag_enable = false
 [[package]]
 name = "my_main_package"
 # (Optional) Customize the git tag name to remove the `my_main_package` prefix.
-git_tag_name = "v${version}"
+git_tag_name = "v{{version}}"
 
 # Enable git tags for this package
 git_tag_enable = true


### PR DESCRIPTION
I copied this example into a project and [release-plz tried to use the literal `v${version}` as a tag][1], since `${}` is not how tera does variables.

[1]: https://github.com/obmarg/cynic/blame/2a0c2b2db127993aa88e78b75b998ae70b2e2c47/CHANGELOG.md#L12