### PR TITLE
chore: rename `--project-manifest` to `--manifest-path` in error messages

### DIFF
--- a/crates/release_plz/src/args/mod.rs
+++ b/crates/release_plz/src/args/mod.rs
@@ -59,8 +59,8 @@ pub enum OutputType {
     Json,
 }
 
-fn local_manifest(project_manifest: Option<&Utf8Path>) -> Utf8PathBuf {
-    match project_manifest {
+fn local_manifest(manifest_path: Option<&Utf8Path>) -> Utf8PathBuf {
+    match manifest_path {
         Some(manifest) => manifest.to_path_buf(),
         None => current_directory().unwrap().join(CARGO_TOML),
     }

--- a/crates/release_plz/src/args/release.rs
+++ b/crates/release_plz/src/args/release.rs
@@ -129,7 +129,7 @@ impl Release {
 }
 
 impl RepoCommand for Release {
-    fn optional_project_manifest(&self) -> Option<&Utf8Path> {
+    fn optional_manifest_path(&self) -> Option<&Utf8Path> {
         self.manifest_path
             .as_deref()
             .map(|p| to_utf8_path(p).unwrap())

--- a/crates/release_plz/src/args/repo_command.rs
+++ b/crates/release_plz/src/args/repo_command.rs
@@ -6,20 +6,20 @@ use crate::config::Config;
 
 /// Command that acts on a repo.
 pub trait RepoCommand {
-    fn optional_project_manifest(&self) -> Option<&Utf8Path>;
+    fn optional_manifest_path(&self) -> Option<&Utf8Path>;
 
     fn repo_url(&self) -> Option<&str>;
 
-    fn project_manifest(&self) -> Utf8PathBuf {
-        super::local_manifest(self.optional_project_manifest())
+    fn manifest_path(&self) -> Utf8PathBuf {
+        super::local_manifest(self.optional_manifest_path())
     }
 
     fn cargo_metadata(&self) -> anyhow::Result<cargo_metadata::Metadata> {
-        let manifest = &self.project_manifest();
+        let manifest = &self.manifest_path();
         cargo_utils::get_manifest_metadata(manifest).map_err(|e| match e {
             cargo_metadata::Error::CargoMetadata { stderr } => {
                 let stderr = stderr.trim();
-                anyhow::anyhow!("{stderr}. Use --project-manifest to specify the path to the manifest file if it's not in the current directory.")
+                anyhow::anyhow!("{stderr}. Use --manifest-path to specify the path to the manifest file if it's not in the current directory.")
             }
             _ => {
                 anyhow::anyhow!(e)
@@ -31,8 +31,8 @@ pub trait RepoCommand {
         match &self.user_repo_url(config) {
             Some(url) => RepoUrl::new(url),
             None => {
-                let project_manifest = self.project_manifest();
-                let project_dir = release_plz_core::manifest_dir(&project_manifest)?;
+                let manifest_path = self.manifest_path();
+                let project_dir = release_plz_core::manifest_dir(&manifest_path)?;
                 let repo = Repo::new(project_dir)?;
                 RepoUrl::from_repo(&repo)
             }

--- a/crates/release_plz/src/args/update.rs
+++ b/crates/release_plz/src/args/update.rs
@@ -28,8 +28,8 @@ pub struct Update {
     /// your project is already available locally.
     /// For example, it could be the path to the project with a `git checkout` on its latest tag.
     /// The git history of this project should be behind the one of the project you want to update.
-    #[arg(long, value_parser = PathBufValueParser::new())]
-    registry_project_manifest: Option<PathBuf>,
+    #[arg(long, value_parser = PathBufValueParser::new(), alias = "registry_project_manifest")]
+    registry_manifest_path: Option<PathBuf>,
     /// Package to update. Use it when you want to update a single package rather than all the
     /// packages contained in the workspace.
     #[arg(
@@ -53,7 +53,7 @@ pub struct Update {
     /// If unspecified, crates.io is used.
     #[arg(
         long,
-        conflicts_with("registry_project_manifest"),
+        conflicts_with("registry_manifest_path"),
         value_parser = NonEmptyStringValueParser::new()
     )]
     registry: Option<String>,
@@ -92,7 +92,7 @@ pub struct Update {
 }
 
 impl RepoCommand for Update {
-    fn optional_project_manifest(&self) -> Option<&Utf8Path> {
+    fn optional_manifest_path(&self) -> Option<&Utf8Path> {
         self.manifest_path
             .as_deref()
             .map(|p| to_utf8_path(p).unwrap())
@@ -121,11 +121,11 @@ impl Update {
         config: Config,
         cargo_metadata: cargo_metadata::Metadata,
     ) -> anyhow::Result<UpdateRequest> {
-        let project_manifest = self.project_manifest();
+        let project_manifest = self.manifest_path();
         check_if_cargo_lock_is_ignored(&project_manifest)?;
         let mut update = UpdateRequest::new(cargo_metadata)
             .with_context(|| {
-                format!("Cannot find file {project_manifest:?}. Make sure you are inside a rust project or that --project-manifest points to a valid Cargo.toml file.")
+                format!("Cannot find file {project_manifest:?}. Make sure you are inside a rust project or that --manifest-path points to a valid Cargo.toml file.")
             })?
             .with_dependencies_update(self.dependencies_update(&config))
             .with_allow_dirty(self.allow_dirty(&config));
@@ -136,12 +136,12 @@ impl Update {
             Err(e) => tracing::warn!("Cannot determine repo url. The changelog won't contain the release link. Error: {:?}", e),
         }
 
-        if let Some(registry_project_manifest) = &self.registry_project_manifest {
-            let registry_project_manifest = to_utf8_path(registry_project_manifest)?;
+        if let Some(registry_manifest_path) = &self.registry_manifest_path {
+            let registry_manifest_path = to_utf8_path(registry_manifest_path)?;
             update = update
-                .with_registry_project_manifest(registry_project_manifest.to_path_buf())
+                .with_registry_manifest_path(registry_manifest_path.to_path_buf())
                 .with_context(|| {
-                    format!("cannot find project manifest {registry_project_manifest:?}")
+                    format!("cannot find project manifest {registry_manifest_path:?}")
                 })?;
         }
         update = config.fill_update_config(self.no_changelog, update);
@@ -234,7 +234,7 @@ mod tests {
     fn input_generates_correct_release_request() {
         let update_args = Update {
             manifest_path: None,
-            registry_project_manifest: None,
+            registry_manifest_path: None,
             package: None,
             no_changelog: false,
             release_date: None,

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -246,10 +246,7 @@ impl UpdateRequest {
         })
     }
 
-    pub fn with_registry_project_manifest(
-        self,
-        registry_manifest: Utf8PathBuf,
-    ) -> io::Result<Self> {
+    pub fn with_registry_manifest_path(self, registry_manifest: Utf8PathBuf) -> io::Result<Self> {
         let registry_manifest = Utf8Path::canonicalize_utf8(&registry_manifest)?;
         Ok(Self {
             registry_manifest: Some(registry_manifest),

--- a/crates/release_plz_core/tests/all/helpers/comparison_test.rs
+++ b/crates/release_plz_core/tests/all/helpers/comparison_test.rs
@@ -49,14 +49,14 @@ impl ComparisonTest {
     }
 
     fn update_request(&self) -> UpdateRequest {
-        let metadata = get_manifest_metadata(&self.local_project_manifest()).unwrap();
+        let metadata = get_manifest_metadata(&self.local_manifest_path()).unwrap();
         UpdateRequest::new(metadata)
             .unwrap()
             .with_changelog_req(ChangelogRequest {
                 release_date: NaiveDate::from_ymd_opt(2015, 5, 15),
                 changelog_config: None,
             })
-            .with_registry_project_manifest(self.registry_project_manfifest())
+            .with_registry_manifest_path(self.registry_project_manfifest())
             .unwrap()
     }
 
@@ -108,7 +108,7 @@ impl ComparisonTest {
         self.registry_project.path().join(PROJECT_NAME)
     }
 
-    pub fn local_project_manifest(&self) -> Utf8PathBuf {
+    pub fn local_manifest_path(&self) -> Utf8PathBuf {
         self.local_project().join(CARGO_TOML)
     }
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
Close https://github.com/MarcoIeni/release-plz/issues/1333