### PR TITLE
fix: use token to fetch sparse metadata

### DIFF
--- a/crates/release_plz_core/src/cargo.rs
+++ b/crates/release_plz_core/src/cargo.rs
@@ -3,6 +3,8 @@ use cargo_metadata::{camino::Utf8Path, Package};
 use crates_index::{Crate, GitIndex, SparseIndex};
 use tracing::{debug, info};
 
+use http::header;
+use secrecy::{ExposeSecret, SecretString};
 use std::{
     env,
     process::{Command, ExitStatus},
@@ -51,11 +53,12 @@ pub async fn is_published(
     index: &mut CargoIndex,
     package: &Package,
     timeout: Duration,
+    token: &Option<SecretString>,
 ) -> anyhow::Result<bool> {
     tokio::time::timeout(timeout, async {
         match index {
             CargoIndex::Git(index) => is_published_git(index, package),
-            CargoIndex::Sparse(index) => is_in_cache_sparse(index, package).await,
+            CargoIndex::Sparse(index) => is_in_cache_sparse(index, package, token).await,
         }
     })
     .await?
@@ -81,8 +84,12 @@ fn is_in_cache_git(index: &GitIndex, package: &Package) -> bool {
     is_in_cache(crate_data.as_ref(), version)
 }
 
-async fn is_in_cache_sparse(index: &SparseIndex, package: &Package) -> anyhow::Result<bool> {
-    let crate_data = fetch_sparse_metadata(index, &package.name)
+async fn is_in_cache_sparse(
+    index: &SparseIndex,
+    package: &Package,
+    token: &Option<SecretString>,
+) -> anyhow::Result<bool> {
+    let crate_data = fetch_sparse_metadata(index, &package.name, token)
         .await
         .context("failed fetching sparse metadata")?;
     let version = &package.version.to_string();
@@ -105,12 +112,21 @@ fn is_version_present(version: &str, crate_data: &Crate) -> bool {
 async fn fetch_sparse_metadata(
     index: &SparseIndex,
     crate_name: &str,
+    token: &Option<SecretString>,
 ) -> anyhow::Result<Option<Crate>> {
     let req = index.make_cache_request(crate_name)?;
     let (parts, _) = req.body(())?.into_parts();
     let req = http::Request::from_parts(parts, vec![]);
 
-    let req: reqwest::Request = req.try_into()?;
+    let mut req: reqwest::Request = req.try_into()?;
+    if let Some(token) = token {
+        let authorization = token
+            .expose_secret()
+            .parse()
+            .context("parse token as header value")?;
+        req.headers_mut()
+            .insert(header::AUTHORIZATION, authorization);
+    }
 
     let client = reqwest::ClientBuilder::new()
         .gzip(true)
@@ -138,13 +154,14 @@ pub async fn wait_until_published(
     index: &mut CargoIndex,
     package: &Package,
     timeout: Duration,
+    token: &Option<SecretString>,
 ) -> anyhow::Result<()> {
     let now: Instant = Instant::now();
     let sleep_time = Duration::from_secs(2);
     let mut logged = false;
 
     loop {
-        let is_published = is_published(index, package, timeout).await?;
+        let is_published = is_published(index, package, timeout, token).await?;
         if is_published {
             break;
         } else if timeout < now.elapsed() {

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -494,7 +494,7 @@ async fn release_package_if_needed(
         .context("can't determine registry indexes")?;
     let mut package_was_released = true;
     for mut index in registry_indexes {
-        if is_published(&mut index, package, input.publish_timeout)
+        if is_published(&mut index, package, input.publish_timeout, &input.token)
             .await
             .context("can't determine if package is published")?
         {
@@ -604,7 +604,7 @@ async fn release_package(
         Ok(false)
     } else {
         if publish {
-            wait_until_published(index, package, input.publish_timeout).await?;
+            wait_until_published(index, package, input.publish_timeout, &input.token).await?;
         }
 
         if input.is_git_tag_enabled(&package.name) {


### PR DESCRIPTION
Fix #1415.