### PR TITLE
fix: updating pr persists gh verified status

### DIFF
--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -133,6 +133,11 @@ impl Repo {
     }
 
     pub fn force_push(&self, obj: &str) -> anyhow::Result<()> {
+        // `--force-with-lease` is safer than `--force` because it will not overwrite
+        // changes on the remote that you do not have locally.
+        // In other words, it will only push if no one else has pushed changes to the remote
+        // branch since you last pulled. If someone else has pushed changes, the command will fail,
+        // preventing you from accidentally overwriting someone else's work.
         self.git(&["push", &self.original_remote, obj, "--force-with-lease"])?;
         Ok(())
     }

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -133,7 +133,7 @@ impl Repo {
     }
 
     pub fn force_push(&self, obj: &str) -> anyhow::Result<()> {
-        self.git(&["push", &self.original_remote, obj, "--force"])?;
+        self.git(&["push", &self.original_remote, obj, "--force-with-lease"])?;
         Ok(())
     }
 


### PR DESCRIPTION
When updating PR on github, force push the rebased branch first and create commit through API to keep the verified status of the commit.

Fixes #1406 