### PR TITLE
fix(#1487): don't close release PR on force-push

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,6 +4130,7 @@ dependencies = [
  "lazy_static",
  "next_version 0.2.17",
  "parse-changelog",
+ "rand",
  "rayon",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ once_cell = "1.19.0"
 parse-changelog = { version = "0.6.8", default-features = false }
 pretty_assertions = "1.4.0"
 rayon = "1.10.0"
+rand = "0.8.5"
 regex = "1.10.4"
 reqwest = "0.12.4"
 reqwest-middleware = { version = "0.3.1", features = ["json"] }

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -288,6 +288,11 @@ impl Repo {
         .is_ok()
     }
 
+    /// Name of the remote when the [`Repo`] was created.
+    pub fn original_remote(&self) -> &str {
+        &self.original_remote
+    }
+
     /// Url of the remote when the [`Repo`] was created.
     pub fn original_remote_url(&self) -> anyhow::Result<String> {
         let param = format!("remote.{}.url", self.original_remote);

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -85,6 +85,11 @@ impl Repo {
         Ok(())
     }
 
+    pub fn delete_branch_in_remote(&self, branch: &str) -> anyhow::Result<()> {
+        self.push(&format!(":refs/heads/{branch}"))
+            .with_context(|| format!("can't delete temporary branch {branch}"))
+    }
+
     pub fn add_all_and_commit(&self, message: &str) -> anyhow::Result<()> {
         self.git(&["add", "."])?;
         self.git(&["commit", "-m", message])?;

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -33,6 +33,7 @@ git-url-parse.workspace = true
 ignore.workspace = true
 lazy_static.workspace = true
 parse-changelog.workspace = true
+rand.workspace = true
 rayon.workspace = true
 regex.workspace = true
 # native-tls-alpn is needed for http2 support. https://doc.rust-lang.org/cargo/reference/registry-index.html#sparse-protocol

--- a/crates/release_plz_core/src/command/release_pr.rs
+++ b/crates/release_plz_core/src/command/release_pr.rs
@@ -324,8 +324,7 @@ async fn github_force_push(
         tmp_release_branch,
         pr.branch()
     ))?;
-    // delete the temporary branch in remote
-    repository.push(&format!(":refs/heads/{tmp_release_branch}"))?;
+    repository.delete_branch_in_remote(&tmp_release_branch)?;
 
     Ok(())
 }

--- a/crates/release_plz_core/src/git/github_graphql.rs
+++ b/crates/release_plz_core/src/git/github_graphql.rs
@@ -11,6 +11,7 @@ use crate::GitClient;
 
 /// Commit all the changes (except typestates) that are present in the repository
 /// using GitHub's [GraphQL api](https://docs.github.com/en/graphql/reference/mutations#createcommitonbranch).
+/// We use this API, because it gives the "Verified" status to the commit without a GPG key.
 pub async fn commit_changes(
     client: &GitClient,
     repo: &Repo,


### PR DESCRIPTION
Fixes #1487 

Force pushing a branch that links to an open PR with the content of a base branch automatically closes it. To prevent that we create a new temporary branch for release, commit there and then force push original one.
