### PR TITLE
feat(backend): GitLab on-premise support and multilevel URLs, SSH git repos

### DIFF
--- a/crates/release_plz/src/args/release.rs
+++ b/crates/release_plz/src/args/release.rs
@@ -45,7 +45,7 @@ pub struct Release {
     /// It defaults to the url of the default remote.
     #[arg(long, value_parser = NonEmptyStringValueParser::new())]
     pub repo_url: Option<String>,
-    /// Git token used to publish the GitHub release.
+    /// Git token used to publish the GitHub/Gitea/GitLab release.
     #[arg(long, value_parser = NonEmptyStringValueParser::new(), env, hide_env_values=true)]
     pub git_token: Option<String>,
     /// Kind of git backend

--- a/crates/release_plz/src/args/release.rs
+++ b/crates/release_plz/src/args/release.rs
@@ -99,7 +99,7 @@ impl Release {
                         GitBackend::Github(GitHub::new(repo_url.owner, repo_url.name, git_token))
                     }
                     ReleaseGitBackendKind::Gitlab => {
-                        GitBackend::Gitlab(GitLab::new(repo_url.owner, repo_url.name, git_token))
+                        GitBackend::Gitlab(GitLab::new(repo_url, git_token)?)
                     }
                 },
             };

--- a/crates/release_plz/src/main.rs
+++ b/crates/release_plz/src/main.rs
@@ -68,10 +68,10 @@ async fn run(args: CliArgs) -> anyhow::Result<()> {
             let config = cmd_args.config()?;
             let cmd_args_output = cmd_args.output;
             let request: ReleaseRequest = cmd_args.release_request(&config, cargo_metadata)?;
+            let output = release_plz_core::release(&request)
+                .await?
+                .unwrap_or_default();
             if let Some(output_type) = cmd_args_output {
-                let output = release_plz_core::release(&request)
-                    .await?
-                    .unwrap_or_default();
                 print_output(output_type, output);
             }
         }

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -219,10 +219,7 @@ impl GitClient {
             description: &release_info.release_body,
         };
         self.client
-            .post(format!(
-                "{}/projects/{}%2F{}/releases",
-                self.remote.base_url, self.remote.owner, self.remote.repo
-            ))
+            .post(format!("{}/releases", self.remote.base_url))
             .json(&gitlab_release_options)
             .send()
             .await?

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -218,7 +218,17 @@ impl GitClient {
             .json(&gitlab_release_options)
             .send()
             .await?
-            .error_for_status()?;
+            .error_for_status()
+            .map_err(|e| {
+                if let Some(status) = e.status() {
+                    if status == reqwest::StatusCode::FORBIDDEN {
+                        return anyhow::anyhow!(e).context(
+                            "Make sure your token has sufficient permissions. Learn more at https://release-plz.ieni.dev/docs/usage/release#gitlab",
+                        );
+                    }
+                }
+                anyhow::anyhow!(e)
+            })?;
         Ok(())
     }
 

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -62,6 +62,7 @@ pub struct PrCommit {
     pub author: Option<Author>,
 }
 
+#[allow(dead_code)]
 #[derive(Deserialize)]
 pub struct CommitParent {
     pub sha: String,

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -62,7 +62,6 @@ pub struct PrCommit {
     pub author: Option<Author>,
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 pub struct Author {
     login: String,

--- a/crates/release_plz_core/src/git/gitlab_client.rs
+++ b/crates/release_plz_core/src/git/gitlab_client.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::{ExposeSecret, SecretString};
+use tracing::debug;
 
 use crate::{git::backend::Remote, RepoUrl};
 
@@ -16,6 +17,8 @@ impl GitLab {
             .parse()
             .context("invalid GitLab API URL")?;
 
+        debug!("GitLab API URL: {base_url}");
+
         Ok(Self {
             remote: Remote {
                 base_url,
@@ -28,20 +31,17 @@ impl GitLab {
 
     pub fn default_headers(&self) -> anyhow::Result<HeaderMap> {
         let mut headers = HeaderMap::new();
-        headers.insert(
-            reqwest::header::HeaderName::from_static("content-type"),
-            reqwest::header::HeaderValue::from_static("application/json"),
-        );
-        let auth_header: HeaderValue = self
+        headers.insert("content-type", HeaderValue::from_static("application/json"));
+
+        let mut private_token: HeaderValue = self
             .remote
             .token
             .expose_secret()
             .parse()
             .context("Invalid Gitlab token")?;
-        headers.insert(
-            reqwest::header::HeaderName::from_static("private-token"),
-            auth_header,
-        );
+        private_token.set_sensitive(true);
+        headers.insert("PRIVATE-TOKEN", private_token);
+
         Ok(headers)
     }
 }

--- a/crates/release_plz_core/src/git/gitlab_client.rs
+++ b/crates/release_plz_core/src/git/gitlab_client.rs
@@ -31,7 +31,10 @@ impl GitLab {
 
     pub fn default_headers(&self) -> anyhow::Result<HeaderMap> {
         let mut headers = HeaderMap::new();
-        headers.insert("content-type", HeaderValue::from_static("application/json"));
+        headers.insert(
+            reqwest::header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
 
         let mut private_token: HeaderValue = self
             .remote

--- a/crates/release_plz_core/src/repo_url.rs
+++ b/crates/release_plz_core/src/repo_url.rs
@@ -9,6 +9,7 @@ pub struct RepoUrl {
     port: Option<u16>,
     pub owner: String,
     pub name: String,
+    pub path: String,
 }
 
 impl RepoUrl {
@@ -24,12 +25,18 @@ impl RepoUrl {
             .with_context(|| format!("cannot find host in git url {git_host_url}"))?;
         let port = git_url.port;
         let scheme = git_url.scheme.to_string();
+        let path = git_url
+            .path
+            .strip_suffix(".git")
+            .unwrap_or(&git_url.path)
+            .to_string();
         Ok(RepoUrl {
             owner,
             name,
             host,
             port,
             scheme,
+            path,
         })
     }
 
@@ -73,6 +80,25 @@ impl RepoUrl {
             format!("{}://{}/{v1}", self.scheme, self.host)
         }
     }
+
+    pub fn gitlab_api_url(&self) -> String {
+        let v4 = "api/v4/projects";
+        let prj_path = self
+            .path
+            .strip_prefix("/")
+            .unwrap_or(&self.path)
+            .replace("/", "%2F");
+        let scheme = if self.scheme == "ssh" {
+            "https"
+        } else {
+            self.scheme.as_str()
+        };
+        if let Some(port) = self.port {
+            format!("{scheme}://{}:{port}/{v4}/{prj_path}", self.host)
+        } else {
+            format!("{scheme}://{}/{v4}/{prj_path}", self.host)
+        }
+    }
 }
 #[cfg(test)]
 mod tests {
@@ -101,5 +127,20 @@ mod tests {
         let expected_url = format!("{GITHUB_REPO_URL}/compare/{previous_tag}...{next_tag}");
         let release_link = repo.git_release_link(previous_tag, next_tag);
         assert_eq!(expected_url, release_link);
+    }
+
+    #[test]
+    fn gitlab_api_url() {
+        let git_repo = RepoUrl::new("git@host.example.com:ab/cd/myproj.git").unwrap();
+        assert_eq!(
+            "https://host.example.com/api/v4/projects/ab%2Fcd%2Fmyproj",
+            git_repo.gitlab_api_url()
+        );
+
+        let http_repo = RepoUrl::new("https://host.example.com/ab/cd/myproj.git").unwrap();
+        assert_eq!(
+            "https://host.example.com/api/v4/projects/ab%2Fcd%2Fmyproj",
+            http_repo.gitlab_api_url()
+        );
     }
 }

--- a/crates/release_plz_core/src/repo_url.rs
+++ b/crates/release_plz_core/src/repo_url.rs
@@ -85,9 +85,9 @@ impl RepoUrl {
         let v4 = "api/v4/projects";
         let prj_path = self
             .path
-            .strip_prefix("/")
+            .strip_prefix('/')
             .unwrap_or(&self.path)
-            .replace("/", "%2F");
+            .replace('/', "%2F");
         let scheme = if self.scheme == "ssh" {
             "https"
         } else {

--- a/website/docs/usage/release.md
+++ b/website/docs/usage/release.md
@@ -29,24 +29,30 @@ To learn more, run `release-plz release --help`.
 
 ## Gitlab
 
-`releases-plz` also supports creating releases on Gitlab with the `--backend gitlab` option.
+`releases-plz` supports creating releases on Gitlab with the `--backend gitlab` option.
 
 The default token in CI does not have permissions to create tags, so you will need to
 a custom [access token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html).
 The permissions you need are:
 
-- `api` (to create a release)
-- `write_repository` (to create tag)
+- Role: `Maintainer` or higher
+- Scopes:
+  - `api` (to create a release)
+  - `write_repository` (to create tag)
 
 Then you can run `release-plz release` in Gitlab CI with the following arguments:
 
-`release-plz release --backend gitlab --git-token <gitlab application token>`
+`release-plz release --backend gitlab --git-token <gitlab_token>`
 
 ## Gitea
 
-`releases-plz` also supports creating releases on Gitea with the `--backend gitea` option.
+`releases-plz` supports creating releases on Gitea with the `--backend gitea` option.
 
 TODO: document how to create a token on Gitea.
+
+Then you can run `release-plz release` in Gitea CI with the following arguments:
+
+`release-plz release --backend gitea --git-token <gitea_token>`
 
 ## Json output
 
@@ -71,17 +77,17 @@ Example:
 ```json
 {
   "releases": [
-      {
-        "package_name": "my_crate",
-        "prs": [
-          {
-            "html_url": "https://github.com/user/proj/pull/1439",
-            "number": 1439
-          }
-        ],
-        "tag": "v0.1.0",
-        "version": "0.1.0"
-      }
+    {
+      "package_name": "my_crate",
+      "prs": [
+        {
+          "html_url": "https://github.com/user/proj/pull/1439",
+          "number": 1439
+        }
+      ],
+      "tag": "v0.1.0",
+      "version": "0.1.0"
+    }
   ]
 }
 ```


### PR DESCRIPTION
- Add support for on-premise hosted GitLab, not only gitlab.com
- Add support for SSH git repositories -> will be converted to "https" API URL
- Add support for multi level gitlab groups
- Respect upper case PRIVATE-TOKEN header
- Mark PRIVATE-TOKEN header value as sensitive
- fix bug: release-plz release fails when no "-o json" given as argument