### PR TITLE
fix: release command if `-o` isn't specified

### DIFF
--- a/crates/release_plz/src/main.rs
+++ b/crates/release_plz/src/main.rs
@@ -68,10 +68,10 @@ async fn run(args: CliArgs) -> anyhow::Result<()> {
             let config = cmd_args.config()?;
             let cmd_args_output = cmd_args.output;
             let request: ReleaseRequest = cmd_args.release_request(&config, cargo_metadata)?;
+            let output = release_plz_core::release(&request)
+                .await?
+                .unwrap_or_default();
             if let Some(output_type) = cmd_args_output {
-                let output = release_plz_core::release(&request)
-                    .await?
-                    .unwrap_or_default();
                 print_output(output_type, output);
             }
         }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
Extracted from https://github.com/MarcoIeni/release-plz/pull/1521