### PR TITLE
feat: automatically set git-cliff remote from git remote

### DIFF
--- a/crates/release_plz/src/args/update.rs
+++ b/crates/release_plz/src/args/update.rs
@@ -162,18 +162,7 @@ impl Update {
 
             let changelog_req = ChangelogRequest {
                 release_date,
-                changelog_config: Some(
-                    self.changelog_config(
-                        &config,
-                        self.get_repo_url(&config)
-                            .map(|r| Remote {
-                                owner: r.owner.clone(),
-                                repo: r.name.clone(),
-                                token: None,
-                            })
-                            .ok(),
-                    )?,
-                ),
+                changelog_config: Some(self.changelog_config(&config)?),
             };
             update = update.with_changelog_req(changelog_req);
         }
@@ -190,11 +179,16 @@ impl Update {
         Ok(update)
     }
 
-    fn changelog_config(
-        &self,
-        config: &Config,
-        upstream_remote: Option<Remote>,
-    ) -> anyhow::Result<GitCliffConfig> {
+    fn changelog_config(&self, config: &Config) -> anyhow::Result<GitCliffConfig> {
+        let upstream_remote = self
+            .get_repo_url(config)
+            .map(|r| Remote {
+                owner: r.owner.clone(),
+                repo: r.name.clone(),
+                token: None,
+            })
+            .ok();
+
         let default_config_path = dirs::config_dir()
             .context("cannot get config dir")?
             .join("git-cliff")

--- a/website/docs/changelog-format.md
+++ b/website/docs/changelog-format.md
@@ -104,6 +104,37 @@ you can use the following context in the template:
 }
 ```
 
+#### Forge integration
+
+Release-plz will try to guess your repository based on the remote configured in git.
+It will then make this information available as extra context.
+
+```json
+{
+  ...,
+  "remote": {
+    "github": {
+      "owner": "orhun",
+      "repo": "git-cliff"
+    },
+    "gitlab": {
+      "owner": "orhun",
+      "repo": "git-cliff"
+    },
+    "gitea": {
+      "owner": "orhun",
+      "repo": "git-cliff"
+    },
+    "bitbucket": {
+      "owner": "orhun",
+      "repo": "git-cliff"
+    }
+  }
+}
+```
+
+git-cliff will then make available [the integrations it has with each forge](https://git-cliff.org/docs/integration/github).
+
 #### Footers
 
 A conventional commit's body may end with any number of structured key-value pairs known as


### PR DESCRIPTION
<!-- Please explain the changes you made -->

This automatically sets git cliff's `config.remote.*.owner` / `.repo`, so that it matches the [git-cliff CLI behavior](https://github.com/orhun/git-cliff/blob/e7807e13c4b38aaa4a735ff05b69fdd6b57a7a85/git-cliff/src/lib.rs#L117) and more of git-cliff's example templates work by default.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
