### PR TITLE
release dev-dependencies from workspace before self

### DIFF
--- a/crates/release_plz_core/src/release_order.rs
+++ b/crates/release_plz_core/src/release_order.rs
@@ -77,7 +77,7 @@ fn is_dep_in_features(pkg: &Package, dep: &str) -> bool {
 /// Check if the dependency should be released before the current package.
 fn should_dep_be_released_before(dep: &Dependency, pkg: &Package) -> bool {
     // Ignore development dependencies. They don't need to be published before the current package...
-    matches!(dep.kind, DependencyKind::Normal | DependencyKind::Build)
+    matches!(dep.kind, DependencyKind::Normal | DependencyKind::Build | DependencyKind::Development)
       // ...unless they are in features. In fact, `cargo-publish` compiles crates that are in features
       // and dev-dependencies, even if they are not present in normal dependencies.
       || is_dep_in_features(pkg, &dep.name)


### PR DESCRIPTION
## Issue

`cargo publish` will check all dependencies, including `dev-dependencies` when verifying a project. You can minimally verify this behavior by adding a non-existent dev-dep to any Cargo project and attempting to run `cargo package`.

Here's a tiny synthetic example to illustrate:

![image](https://github.com/user-attachments/assets/ff398633-3f52-4930-a6ef-8ebcf01a43b9)


This is causing the release publishes to fail when you have a workspace where one crate depends on the other thru dev-dependencies, for example if used in benchmarking code.

We're hitting this issue in the Vortex repo trying to cut releases of our mega-workspace.

* Link to failure: https://github.com/spiraldb/vortex/actions/runs/10319405282/job/28567713447#step:7:787
* link to `Cargo.toml` for the crate that's failing to publish: https://github.com/spiraldb/vortex/blob/develop/vortex-serde/Cargo.toml#L45



## Contribution requirements

* I've verified that `cargo fmt` runs cleanly
* Some tests are failing, however these tests are already failing on `main`:

```
failures:
    changelog::can_generate_single_changelog_for_multiple_packages_in_pr
    changelog::can_generate_single_changelog_for_multiple_packages_locally
    changelog::release_plz_adds_changelog_on_new_project
    changelog::release_plz_adds_custom_changelog
    changelog::release_plz_does_not_open_release_pr_if_there_are_no_release_commits
    changelog::release_plz_releases_a_new_project
    helpers::gitea::gitea_new::can_create_gitea_repository
    release::release_info_contains_prs_in_changelog
    release::release_plz_does_not_release_a_new_project_if_release_always_is_false
    release::release_plz_does_not_releases_twice
    release::release_plz_releases_a_new_project_with_custom_release
    release::release_plz_releases_a_new_project_with_custom_tag_name
    release::release_plz_releases_after_release_pr_merged
```