### PR TITLE
Add version of the packages into PR name if they all use the same

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ cargo test
 
 We use Gitea as a Git server for our integration tests.
 
-- Start the Gitea server with `cd tests && docker-compose up`.
+- Start the Gitea server with `cd tests && docker compose up`.
 - See their OpenAPI documentation at `http://localhost:3000/api/swagger`.
 
 If you don't want to run tests that need docker, you can run `cargo test --no-default-features`.

--- a/crates/release_plz_core/src/command/release_pr.rs
+++ b/crates/release_plz_core/src/command/release_pr.rs
@@ -62,7 +62,7 @@ pub struct ReleasePr {
 
 /// Open a pull request with the next packages versions of a local rust project
 /// Returns:
-/// - [`ReleasePrOutcome`] if release-plz opened or updated a PR.
+/// - [`ReleasePr`] if release-plz opened or updated a PR.
 /// - [`None`] if release-plz didn't open any pr. This happens when all packages
 ///   are up-to-date.
 #[instrument(skip_all)]

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -302,7 +302,7 @@ impl GitClient {
             .query(&[(self.per_page(), page_size)])
             .send()
             .await?
-            .bail_on_error()
+            .successful_status()
             .await?
             .json()
             .await
@@ -346,7 +346,7 @@ impl GitClient {
             }))
             .send()
             .await?
-            .bail_on_error()
+            .successful_status()
             .await?
             .json()
             .await
@@ -375,7 +375,7 @@ impl GitClient {
             }))
             .send()
             .await?
-            .bail_on_error()
+            .successful_status()
             .await?;
         Ok(())
     }
@@ -385,7 +385,7 @@ impl GitClient {
             .get(format!("{}/{}/commits", self.pulls_url(), pr_number))
             .send()
             .await?
-            .bail_on_error()
+            .successful_status()
             .await?
             .json()
             .await
@@ -459,11 +459,11 @@ pub fn contributors_from_commits(commits: &[PrCommit]) -> Vec<String> {
 }
 
 trait ResponseExt {
-    async fn bail_on_error(self) -> anyhow::Result<reqwest::Response>;
+    async fn successful_status(self) -> anyhow::Result<reqwest::Response>;
 }
 
 impl ResponseExt for reqwest::Response {
-    async fn bail_on_error(self) -> anyhow::Result<reqwest::Response> {
+    async fn successful_status(self) -> anyhow::Result<reqwest::Response> {
         let Err(err) = self.error_for_status_ref() else {
             return Ok(self);
         };

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -471,7 +471,10 @@ impl ResponseExt for reqwest::Response {
             return Ok(self);
         };
 
-        let mut body = self.text().await?;
+        let mut body = self
+            .text()
+            .await
+            .context("can't convert response body to text")?;
 
         // If the response is JSON, try to pretty-print it.
         if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -459,6 +459,9 @@ pub fn contributors_from_commits(commits: &[PrCommit]) -> Vec<String> {
 }
 
 trait ResponseExt {
+    /// Better version of [`reqwest::Response::error_for_status`] that
+    /// also captures the response body in the error message. It will most
+    /// likely contain additional error details.
     async fn successful_status(self) -> anyhow::Result<reqwest::Response>;
 }
 

--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -478,7 +478,7 @@ impl ResponseExt for reqwest::Response {
             body = format!("{json:#}");
         }
 
-        Err(err).context(anyhow::anyhow!("Response body:\n{body}"))
+        Err(err).context(format!("Response body:\n{body}"))
     }
 }
 

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -1,6 +1,5 @@
-use chrono::SecondsFormat;
-
 use crate::PackagesUpdate;
+use chrono::SecondsFormat;
 
 pub const BRANCH_PREFIX: &str = "release-plz-";
 pub const OLD_BRANCH_PREFIX: &str = "release-plz/";
@@ -55,15 +54,23 @@ fn pr_title(
     packages_to_update: &PackagesUpdate,
     project_contains_multiple_pub_packages: bool,
 ) -> String {
-    if packages_to_update.updates().len() > 1 {
-        "chore: release".to_string()
-    } else {
-        let (package, update) = &packages_to_update.updates()[0];
-        if project_contains_multiple_pub_packages {
-            format!("chore({}): release v{}", package.name, update.version)
-        } else {
-            format!("chore: release v{}", update.version)
+    let updates = packages_to_update.updates();
+
+    if let [(_, first_update), rest @ ..] = updates {
+        let version = &first_update.version;
+
+        if rest.iter().all(|(_, update)| update.version == *version) {
+            return format!("chore: release v{version}");
         }
+
+        return "chore: release".to_string();
+    }
+
+    let (package, update) = &updates[0];
+    if project_contains_multiple_pub_packages {
+        format!("chore({}): release v{}", package.name, update.version)
+    } else {
+        format!("chore: release v{}", update.version)
     }
 }
 

--- a/crates/test_logs/src/lib.rs
+++ b/crates/test_logs/src/lib.rs
@@ -7,7 +7,7 @@ pub fn init() {
     Lazy::force(&TEST_LOGS);
 }
 
-/// Initialize logs if `ENALBE_LOGS` environment variable is set.
+/// Initialize logs if `ENABLE_LOGS` environment variable is set.
 /// Use `debug` level by default, but you can customize it with `RUST_LOG` environment variable.
 fn _init() {
     if std::env::var("ENABLE_LOGS").is_ok() {


### PR DESCRIPTION
Closes https://github.com/MarcoIeni/release-plz/issues/1582

I tested this manually in my repo here: https://github.com/elastio/bon/pull/46.

While testing it I mistakenly tried to run `release-pr` command from the branch that doesn't exist on remote. `release-plz` was subsequently returning an error that didn't actually say what the problem was. It just said that it failed to open a PR with status `422`. I improved the error rendering for the `GitClient` by outputting the response body as well which contained the detail that `base` field of the PR was not valid.