### PR TITLE
chore: ignore rust ci when editing js and ts files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:
       - main
     paths-ignore:
       - "**.md"
+      - '**.js'
+      - '**.ts'
   pull_request:
     paths-ignore:
       - "**.md"
+      - '**.js'
+      - '**.ts'
 
 jobs:
   test:


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
