### PR TITLE
fix(ci): don't run cargo-deny twice in CI

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -3,11 +3,13 @@ name: Security audit
 on:
   schedule:
     # Runs at 00:00 UTC everyday
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
   push:
+    branches:
+      - main
     paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
   pull_request:
 
 jobs:


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
