### PR TITLE
feat: Add `features_always_increment_minor` flag

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -282,7 +282,7 @@
           ]
         },
         "features_always_increment_minor": {
-          "title": "Features Always Increment Minor Version Flag",
+          "title": "Features Always Increment Minor Version",
           "description": "- If `true`, feature commits will always bump the minor version, even in 0.x releases. - If `false` (default), feature commits will only bump the minor version starting with 1.x releases.",
           "type": [
             "boolean",
@@ -520,7 +520,7 @@
           ]
         },
         "features_always_increment_minor": {
-          "title": "Features Always Increment Minor Version Flag",
+          "title": "Features Always Increment Minor Version",
           "description": "- If `true`, feature commits will always bump the minor version, even in 0.x releases. - If `false` (default), feature commits will only bump the minor version starting with 1.x releases.",
           "type": [
             "boolean",

--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -41,6 +41,7 @@
         "changelog_path": null,
         "changelog_update": null,
         "dependencies_update": null,
+        "features_always_increment_minor": null,
         "git_release_body": null,
         "git_release_draft": null,
         "git_release_enable": null,
@@ -280,6 +281,14 @@
             "null"
           ]
         },
+        "features_always_increment_minor": {
+          "title": "Features Always Increment Minor Version Flag",
+          "description": "- If `true`, feature commits will always bump the minor version, even in 0.x releases. - If `false` (default), feature commits will only bump the minor version starting with 1.x releases.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "git_release_body": {
           "title": "Git Release Body",
           "description": "Tera template of the git release body created by release-plz.",
@@ -505,6 +514,14 @@
         "dependencies_update": {
           "title": "Dependencies Update",
           "description": "- If `true`, update all the dependencies in the Cargo.lock file by running `cargo update`. - If `false` or [`Option::None`], only update the workspace packages by running `cargo update --workspace`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "features_always_increment_minor": {
+          "title": "Features Always Increment Minor Version Flag",
+          "description": "- If `true`, feature commits will always bump the minor version, even in 0.x releases. - If `false` (default), feature commits will only bump the minor version starting with 1.x releases.",
           "type": [
             "boolean",
             "null"

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -344,7 +344,9 @@ impl PackageConfig {
             semver_check: self.semver_check.or(default.semver_check),
             changelog_path: self.changelog_path.or(default.changelog_path),
             changelog_update: self.changelog_update.or(default.changelog_update),
-            features_always_increment_minor: self.features_always_increment_minor.or(default.features_always_increment_minor),
+            features_always_increment_minor: self
+                .features_always_increment_minor
+                .or(default.features_always_increment_minor),
             git_release_enable: self.git_release_enable.or(default.git_release_enable),
             git_release_type: self.git_release_type.or(default.git_release_type),
             git_release_draft: self.git_release_draft.or(default.git_release_draft),

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -264,7 +264,7 @@ pub struct PackageConfig {
     /// Whether to create/update changelog or not.
     /// If unspecified, the changelog is updated.
     pub changelog_update: Option<bool>,
-    /// # Features Always Increment Minor Version Flag
+    /// # Features Always Increment Minor Version
     /// - If `true`, feature commits will always bump the minor version, even in 0.x releases.
     /// - If `false` (default), feature commits will only bump the minor version starting with 1.x releases.
     pub features_always_increment_minor: Option<bool>,

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -264,6 +264,10 @@ pub struct PackageConfig {
     /// Whether to create/update changelog or not.
     /// If unspecified, the changelog is updated.
     pub changelog_update: Option<bool>,
+    /// # Features Always Increment Minor Version Flag
+    /// - If `true`, feature commits will always bump the minor version, even in 0.x releases.
+    /// - If `false` (default), feature commits will only bump the minor version starting with 1.x releases.
+    pub features_always_increment_minor: Option<bool>,
     /// # Git Release Enable
     /// Publish the GitHub/Gitea release for the created git tag.
     /// Enabled by default.
@@ -318,6 +322,7 @@ impl From<PackageConfig> for release_plz_core::UpdateConfig {
             changelog_update: config.changelog_update != Some(false),
             release: config.release != Some(false),
             tag_name_template: config.git_tag_name,
+            features_always_increment_minor: config.features_always_increment_minor == Some(true),
             changelog_path: config.changelog_path.map(|p| to_utf8_pathbuf(p).unwrap()),
         }
     }
@@ -339,6 +344,7 @@ impl PackageConfig {
             semver_check: self.semver_check.or(default.semver_check),
             changelog_path: self.changelog_path.or(default.changelog_path),
             changelog_update: self.changelog_update.or(default.changelog_update),
+            features_always_increment_minor: self.features_always_increment_minor.or(default.features_always_increment_minor),
             git_release_enable: self.git_release_enable.or(default.git_release_enable),
             git_release_type: self.git_release_type.or(default.git_release_type),
             git_release_draft: self.git_release_draft.or(default.git_release_draft),

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -3,6 +3,7 @@ use cargo_utils::LocalManifest;
 use crate::helpers::test_context::TestContext;
 
 #[tokio::test]
+#[ignore = "This test fails in CI, but works locally on MacOS. TODO: fix this."]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_detects_edited_readme_cargo_toml_field() {
     let context = TestContext::new().await;
@@ -36,6 +37,7 @@ async fn release_plz_detects_edited_readme_cargo_toml_field() {
 }
 
 #[tokio::test]
+#[ignore = "This test fails in CI, but works locally on MacOS. TODO: fix this."]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_honors_features_always_increment_minor_flag() {
     let context = TestContext::new().await;

--- a/crates/release_plz/tests/all/release_pr.rs
+++ b/crates/release_plz/tests/all/release_pr.rs
@@ -3,7 +3,6 @@ use cargo_utils::LocalManifest;
 use crate::helpers::test_context::TestContext;
 
 #[tokio::test]
-#[ignore = "This test fails in CI, but works locally on MacOS. TODO: fix this."]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_detects_edited_readme_cargo_toml_field() {
     let context = TestContext::new().await;
@@ -31,12 +30,12 @@ async fn release_plz_detects_edited_readme_cargo_toml_field() {
     assert_eq!(gitea_release.name, expected_tag);
     expect_test::expect![[r#"
         ### Other
+
         - move readme"#]]
     .assert_eq(&gitea_release.body);
 }
 
 #[tokio::test]
-#[ignore = "This test fails in CI, but works locally on MacOS. TODO: fix this."]
 #[cfg_attr(not(feature = "docker-tests"), ignore)]
 async fn release_plz_honors_features_always_increment_minor_flag() {
     let context = TestContext::new().await;
@@ -70,6 +69,7 @@ async fn release_plz_honors_features_always_increment_minor_flag() {
     assert_eq!(gitea_release.name, expected_tag);
     expect_test::expect![[r#"
         ### Added
+
         - move readme"#]]
     .assert_eq(&gitea_release.body);
 }

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -203,11 +203,8 @@ impl UpdateConfig {
     }
 
     pub fn version_updater(&self) -> VersionUpdater {
-        let mut vu = VersionUpdater::default();
-        if self.features_always_increment_minor {
-            vu = vu.with_features_always_increment_minor(true);
-        }
-        vu
+        VersionUpdater::default()
+            .with_features_always_increment_minor(self.features_always_increment_minor)
     }
 }
 

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -181,7 +181,10 @@ impl UpdateConfig {
         }
     }
 
-    pub fn with_features_always_increment_minor(self, features_always_increment_minor: bool) -> Self {
+    pub fn with_features_always_increment_minor(
+        self,
+        features_always_increment_minor: bool,
+    ) -> Self {
         Self {
             features_always_increment_minor,
             ..self
@@ -493,10 +496,12 @@ impl Updater<'_> {
                 if workspace_version_pkgs.contains(p.name.as_str()) {
                     max_workspace_version.clone()
                 } else {
-                    p.version.next_from_diff_with_updater(&diff, version_updater)
+                    p.version
+                        .next_from_diff_with_updater(&diff, version_updater)
                 }
             } else {
-                p.version.next_from_diff_with_updater(&diff, version_updater)
+                p.version
+                    .next_from_diff_with_updater(&diff, version_updater)
             };
 
             debug!("diff: {:?}, next_version: {}", &diff, next_version);

--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -518,8 +518,7 @@ impl Updater<'_> {
                             })?
                             .clone()
                     } else {
-                        p.version
-                            .next_from_diff_with_updater(&diff, version_updater)
+                        p.version.next_from_diff(&diff, version_updater)
                     }
                 }
             };
@@ -566,9 +565,7 @@ impl Updater<'_> {
             let pkg_config = self.req.get_package_config(&pkg.name);
             let version_updater = pkg_config.generic.version_updater();
             if let Some(version_group) = pkg_config.version_group {
-                let next_pkg_ver = pkg
-                    .version
-                    .next_from_diff_with_updater(diff, version_updater);
+                let next_pkg_ver = pkg.version.next_from_diff(diff, version_updater);
                 match version_groups.entry(version_group.clone()) {
                     std::collections::hash_map::Entry::Occupied(v) => {
                         // maximum version of the group until now
@@ -604,7 +601,7 @@ impl Updater<'_> {
                     if workspace_package == &p.name {
                         let pkg_config = self.req.get_package_config(&p.name);
                         let version_updater = pkg_config.generic.version_updater();
-                        let next = p.version.next_from_diff_with_updater(diff, version_updater);
+                        let next = p.version.next_from_diff(diff, version_updater);
                         if let Some(workspace_version) = &workspace_version {
                             if &next >= workspace_version {
                                 return Some(next);

--- a/crates/release_plz_core/src/version.rs
+++ b/crates/release_plz_core/src/version.rs
@@ -19,11 +19,7 @@ impl NextVersionFromDiff for Version {
         self.next_from_diff_with_updater(diff, VersionUpdater::default())
     }
 
-    fn next_from_diff_with_updater(
-        &self,
-        diff: &Diff,
-        version_updater: VersionUpdater
-    ) -> Self {
+    fn next_from_diff_with_updater(&self, diff: &Diff, version_updater: VersionUpdater) -> Self {
         if !diff.should_update_version() {
             self.clone()
         } else if matches!(diff.semver_check, SemverCheck::Incompatible(_)) {

--- a/crates/release_plz_core/src/version.rs
+++ b/crates/release_plz_core/src/version.rs
@@ -6,20 +6,11 @@ use crate::{diff::Diff, semver_check::SemverCheck};
 pub(crate) trait NextVersionFromDiff {
     /// Analyze commits and determine which part of version to increment based on
     /// [conventional commits](https://www.conventionalcommits.org/)
-    fn next_from_diff(&self, diff: &Diff) -> Self;
-
-    /// Analyze commits and determine which part of version to increment based on
-    /// [conventional commits](https://www.conventionalcommits.org/) providing
-    /// a specialized version updater.
-    fn next_from_diff_with_updater(&self, diff: &Diff, version_updater: VersionUpdater) -> Self;
+    fn next_from_diff(&self, diff: &Diff, version_updater: VersionUpdater) -> Self;
 }
 
 impl NextVersionFromDiff for Version {
-    fn next_from_diff(&self, diff: &Diff) -> Self {
-        self.next_from_diff_with_updater(diff, VersionUpdater::default())
-    }
-
-    fn next_from_diff_with_updater(&self, diff: &Diff, version_updater: VersionUpdater) -> Self {
+    fn next_from_diff(&self, diff: &Diff, version_updater: VersionUpdater) -> Self {
         if !diff.should_update_version() {
             self.clone()
         } else if matches!(diff.semver_check, SemverCheck::Incompatible(_)) {
@@ -44,7 +35,12 @@ mod tests {
         let registry_package_exists = false;
         let diff = Diff::new(registry_package_exists);
         let version = Version::new(1, 2, 3);
-        assert_eq!(version.clone().next_from_diff(&diff), version);
+        assert_eq!(
+            version
+                .clone()
+                .next_from_diff(&diff, VersionUpdater::default()),
+            version
+        );
     }
 
     #[test]
@@ -59,6 +55,46 @@ mod tests {
             semver_check: SemverCheck::Skipped,
         };
         let version = Version::new(1, 2, 3);
-        assert_eq!(version.next_from_diff(&diff), Version::new(1, 2, 4));
+        assert_eq!(
+            version.next_from_diff(&diff, VersionUpdater::default()),
+            Version::new(1, 2, 4)
+        );
+    }
+
+    #[test]
+    fn next_version_doesnt_bump_0_x_minor_version_for_features() {
+        let diff = Diff {
+            registry_package_exists: true,
+            commits: vec![Commit::new(
+                NO_COMMIT_ID.to_string(),
+                "feat: my change".to_string(),
+            )],
+            is_version_published: true,
+            semver_check: SemverCheck::Skipped,
+        };
+        let version = Version::new(0, 2, 3);
+        assert_eq!(
+            version.next_from_diff(&diff, VersionUpdater::default()),
+            Version::new(0, 2, 4)
+        );
+    }
+
+    #[test]
+    fn next_version_bumps_0_x_minor_version_for_features() {
+        let diff = Diff {
+            registry_package_exists: true,
+            commits: vec![Commit::new(
+                NO_COMMIT_ID.to_string(),
+                "feat: my change".to_string(),
+            )],
+            is_version_published: true,
+            semver_check: SemverCheck::Skipped,
+        };
+        let version = Version::new(0, 2, 3);
+        let updater = VersionUpdater::default().with_features_always_increment_minor(true);
+        assert_eq!(
+            version.next_from_diff(&diff, updater),
+            Version::new(0, 3, 0)
+        );
     }
 }

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -59,7 +59,7 @@ the following sections:
   - [`changelog_config`](#the-changelog_config-field) — Path to the [git-cliff] configuration file.
   - [`changelog_update`](#the-changelog_update-field) — Update changelog.
   - [`dependencies_update`](#the-dependencies_update-field) — Update all dependencies.
-  - [`features_always_increment_minor`](#the-features_always_increment_minor-field) — Increment minor version number for features in 0.x builds.
+  - [`features_always_increment_minor`](#the-features_always_increment_minor-field) — Features increment minor in `0.x` versions.
   - [`git_release_enable`](#the-git_release_enable-field) — Enable git release.
   - [`git_release_name`](#the-git_release_name-field) — Customize git release name pattern.
   - [`git_release_body`](#the-git_release_body-field) — Customize git release body pattern.
@@ -85,7 +85,7 @@ the following sections:
   - [`changelog_include`](#the-changelog_include-field) — Include commits from other packages.
   - [`changelog_path`](#the-changelog_path-field-package-section) — Changelog path.
   - [`changelog_update`](#the-changelog_update-field-package-section) — Update changelog.
-  - [`features_always_increment_minor`](#the-features_always_increment_minor-field-package-section) — Increment minor version number for features in 0.x builds.
+  - [`features_always_increment_minor`](#the-features_always_increment_minor-field-package-section) — Features increment minor in `0.x` versions.
   - [`git_release_enable`](#the-git_release_enable-field-package-section) — Enable git release.
   - [`git_release_name`](#the-git_release_name-field-package-section) — Customize git release name pattern.
   - [`git_release_body`](#the-git_release_body-field-package-section) — Customize git release body pattern.
@@ -529,7 +529,8 @@ This field cannot be set in the `[workspace]` section.
 
 #### The `features_always_increment_minor` field (`package` section)
 
-Overrides the [`workspace.features_always_increment_minor`](#the-features_always_increment_minor-field) field.
+Overrides the [`workspace.features_always_increment_minor`](#the-features_always_increment_minor-field)
+field.
 
 #### The `git_release_enable` field (`package` section)
 

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -59,7 +59,8 @@ the following sections:
   - [`changelog_config`](#the-changelog_config-field) — Path to the [git-cliff] configuration file.
   - [`changelog_update`](#the-changelog_update-field) — Update changelog.
   - [`dependencies_update`](#the-dependencies_update-field) — Update all dependencies.
-  - [`features_always_increment_minor`](#the-features_always_increment_minor-field) — Features increment minor in `0.x` versions.
+  - [`features_always_increment_minor`](#the-features_always_increment_minor-field)
+    — Features increment minor in `0.x` versions.
   - [`git_release_enable`](#the-git_release_enable-field) — Enable git release.
   - [`git_release_name`](#the-git_release_name-field) — Customize git release name pattern.
   - [`git_release_body`](#the-git_release_body-field) — Customize git release body pattern.
@@ -85,7 +86,8 @@ the following sections:
   - [`changelog_include`](#the-changelog_include-field) — Include commits from other packages.
   - [`changelog_path`](#the-changelog_path-field-package-section) — Changelog path.
   - [`changelog_update`](#the-changelog_update-field-package-section) — Update changelog.
-  - [`features_always_increment_minor`](#the-features_always_increment_minor-field-package-section) — Features increment minor in `0.x` versions.
+  - [`features_always_increment_minor`](#the-features_always_increment_minor-field-package-section)
+    — Features increment minor in `0.x` versions.
   - [`git_release_enable`](#the-git_release_enable-field-package-section) — Enable git release.
   - [`git_release_name`](#the-git_release_name-field-package-section) — Customize git release name pattern.
   - [`git_release_body`](#the-git_release_body-field-package-section) — Customize git release body pattern.

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -186,6 +186,13 @@ This field can be overridden in the [`[package]`](#the-package-section) section.
 - If `true`, feature commits will always bump the minor version, even in 0.x releases.
 - If `false` (default), feature commits will only bump the minor version starting with 1.x releases.
 
+:::warning
+This option violates the Cargo SemVer
+[rules](https://doc.rust-lang.org/cargo/reference/semver.html) because the transition from
+`0.x` to `0.(x+1)` is used for breaking changes.
+Instead, new features for `0.x` should bump the version from `0.x.y` to `0.x.(y+1)`.
+:::
+
 #### The `git_release_enable` field
 
 - If `true`, release-plz creates a git release for the created tag. *(Default)*.

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -59,6 +59,7 @@ the following sections:
   - [`changelog_config`](#the-changelog_config-field) — Path to the [git-cliff] configuration file.
   - [`changelog_update`](#the-changelog_update-field) — Update changelog.
   - [`dependencies_update`](#the-dependencies_update-field) — Update all dependencies.
+  - [`features_always_increment_minor`](#the-features_always_increment_minor-field) — Increment minor version number for features in 0.x builds.
   - [`git_release_enable`](#the-git_release_enable-field) — Enable git release.
   - [`git_release_name`](#the-git_release_name-field) — Customize git release name pattern.
   - [`git_release_body`](#the-git_release_body-field) — Customize git release body pattern.
@@ -84,6 +85,7 @@ the following sections:
   - [`changelog_include`](#the-changelog_include-field) — Include commits from other packages.
   - [`changelog_path`](#the-changelog_path-field-package-section) — Changelog path.
   - [`changelog_update`](#the-changelog_update-field-package-section) — Update changelog.
+  - [`features_always_increment_minor`](#the-features_always_increment_minor-field-package-section) — Increment minor version number for features in 0.x builds.
   - [`git_release_enable`](#the-git_release_enable-field-package-section) — Enable git release.
   - [`git_release_name`](#the-git_release_name-field-package-section) — Customize git release name pattern.
   - [`git_release_body`](#the-git_release_body-field-package-section) — Customize git release body pattern.
@@ -176,6 +178,11 @@ This field can be overridden in the [`[package]`](#the-package-section) section.
 
 - If `true`, update all the dependencies in the `Cargo.lock` file by running `cargo update`.
 - If `false`, only update the workspace packages by running `cargo update --workspace`. *(Default)*.
+
+#### The `features_always_increment_minor` field
+
+- If `true`, feature commits will always bump the minor version, even in 0.x releases.
+- If `false` (default), feature commits will only bump the minor version starting with 1.x releases.
 
 #### The `git_release_enable` field
 
@@ -519,6 +526,10 @@ This field cannot be set in the `[workspace]` section.
 
 - If `true`, update the changelog of this package. *(Default)*.
 - If `false`, don't.
+
+#### The `features_always_increment_minor` field (`package` section)
+
+Overrides the [`workspace.features_always_increment_minor`](#the-features_always_increment_minor-field) field.
 
 #### The `git_release_enable` field (`package` section)
 


### PR DESCRIPTION
When enabled (off by default), it triggers a minor version bump for `feat` commits even when the baseline version is 0.x.

This implements the feature requested in #1656.
