### PR TITLE
fix: retrieve token for each package's registry ala `cargo:token`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4130,6 +4130,7 @@ dependencies = [
  "git_cmd",
  "http",
  "ignore",
+ "itertools",
  "lazy_static",
  "next_version 0.2.19",
  "parse-changelog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,6 +555,7 @@ dependencies = [
  "dirs",
  "dunce",
  "fs-err",
+ "secrecy",
  "semver",
  "serde",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,7 @@ dependencies = [
  "dirs",
  "dunce",
  "fs-err",
- "secrecy",
+ "secrecy 0.10.2",
  "semver",
  "serde",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ git-cliff-core = { version = "2.5.0", default-features = false }
 git-url-parse = "0.4.4"
 http = "1.1.0"
 ignore = "0.4.22"
+itertools = "0.13.0"
 lazy_static = "1.5.0"
 once_cell = "1.19.0"
 parse-changelog = { version = "0.6.8", default-features = false }

--- a/crates/cargo_utils/Cargo.toml
+++ b/crates/cargo_utils/Cargo.toml
@@ -22,3 +22,4 @@ toml_edit.workspace = true
 semver.workspace = true
 url.workspace = true
 serde.workspace = true
+secrecy.workspace = true

--- a/crates/cargo_utils/src/lib.rs
+++ b/crates/cargo_utils/src/lib.rs
@@ -3,6 +3,7 @@ mod fs_utils;
 mod local_manifest;
 mod manifest;
 mod registry;
+mod token;
 mod version;
 mod workspace_members;
 
@@ -11,6 +12,7 @@ pub use fs_utils::*;
 pub use local_manifest::*;
 pub use manifest::*;
 pub use registry::*;
+pub use token::*;
 pub use version::*;
 pub use workspace_members::*;
 

--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -107,15 +107,13 @@ pub fn registry_token(registry: &Option<String>) -> anyhow::Result<Option<Secret
 /// Read credentials for a specific registry using environment variables.
 /// <https://doc.rust-lang.org/cargo/reference/registry-authentication.html#cargotoken>
 pub fn registry_token_from_env(registry: &Option<String>) -> Option<SecretString> {
-    if let Some(r) = registry {
-        std::env::var(format!("CARGO_REGISTRIES_{}_TOKEN", r.to_uppercase()))
-            .ok()
-            .map(SecretString::new)
+    let token = if let Some(r) = registry {
+        let env_var = format!("CARGO_REGISTRIES_{}_TOKEN", r.to_uppercase());
+        std::env::var(env_var)
     } else {
         std::env::var("CARGO_REGISTRY_TOKEN")
-            .ok()
-            .map(SecretString::new)
-    }
+    };
+    token.ok().map(SecretString::new)
 }
 
 /// Read credentials for a specific registry using file cargo/credentials.toml.

--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use secrecy::SecretString;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -95,6 +96,53 @@ pub fn registry_url(manifest_path: &Path, registry: Option<&str>) -> anyhow::Res
     Ok(registry_url)
 }
 
+pub fn registry_token(registry: &Option<String>) -> anyhow::Result<Option<SecretString>> {
+    let mut token = registry_token_from_env(registry);
+    if token.is_none() {
+        token = registry_token_from_credential_file(registry)?;
+    }
+    Ok(token)
+}
+
+/// Read credentials for a specific registry using environment variables.
+/// <https://doc.rust-lang.org/cargo/reference/registry-authentication.html#cargotoken>
+pub fn registry_token_from_env(registry: &Option<String>) -> Option<SecretString> {
+    if let Some(r) = registry {
+        std::env::var(format!("CARGO_REGISTRIES_{}_TOKEN", r.to_uppercase()))
+            .ok()
+            .map(SecretString::new)
+    } else {
+        std::env::var("CARGO_REGISTRY_TOKEN")
+            .ok()
+            .map(SecretString::new)
+    }
+}
+
+/// Read credentials for a specific registry using file cargo/credentials.toml.
+/// <https://doc.rust-lang.org/cargo/reference/config.html#credentials>
+pub fn registry_token_from_credential_file(
+    registry: &Option<String>,
+) -> anyhow::Result<Option<SecretString>> {
+    let mut path = cargo_home()?.join("credentials.toml");
+    if !path.exists() {
+        path = cargo_home()?.join("credentials");
+    }
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs_err::read_to_string(path).context("failed to read cargo credentials file")?;
+    let credentials =
+        toml::from_str::<CargoCredentials>(&content).context("Invalid cargo credentials file")?;
+    let token = if let Some(r) = registry {
+        credentials.registries.get(r)
+    } else {
+        credentials.registry.as_ref()
+    }
+    .and_then(|r| r.token.clone())
+    .map(SecretString::new);
+    Ok(token)
+}
+
 #[derive(Debug, Deserialize)]
 struct CargoConfig {
     #[serde(default)]
@@ -115,6 +163,19 @@ struct Registry {
     index: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Default, PartialEq)]
+struct CargoCredentials {
+    #[serde(default)]
+    registry: Option<RegistryToken>,
+    #[serde(default)]
+    registries: HashMap<String, RegistryToken>,
+}
+
+#[derive(Debug, Deserialize, Default, PartialEq)]
+struct RegistryToken {
+    token: Option<String>,
+}
+
 fn cargo_home() -> anyhow::Result<PathBuf> {
     let default_cargo_home = dirs::home_dir()
         .map(|x| x.join(".cargo"))
@@ -123,4 +184,69 @@ fn cargo_home() -> anyhow::Result<PathBuf> {
         .map(PathBuf::from)
         .unwrap_or(default_cargo_home);
     Ok(cargo_home)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_cargo_credentials_both() {
+        let sample = r#"
+            [registry]
+            token = "aaaa"   # Access token for crates.io
+
+            [registries.my]
+            token = "bbb"   # Access token for the named registry
+        "#;
+        let creds = toml::from_str::<CargoCredentials>(sample).unwrap();
+        assert_eq!(
+            creds.registry.and_then(|r| r.token),
+            Some("aaaa".to_string())
+        );
+        assert_eq!(
+            creds.registries.get("my").and_then(|r| r.token.clone()),
+            Some("bbb".to_string())
+        );
+        assert_eq!(
+            creds.registries.get("foo").and_then(|r| r.token.clone()),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_cargo_credentials_cratesio_only() {
+        let sample = r#"
+            [registry]
+            token = "aaaa"   # Access token for crates.io
+        "#;
+        let creds = toml::from_str::<CargoCredentials>(sample).unwrap();
+        assert_eq!(
+            creds.registry.and_then(|r| r.token),
+            Some("aaaa".to_string())
+        );
+        assert_eq!(
+            creds.registries.get("my").and_then(|r| r.token.clone()),
+            None
+        );
+        assert_eq!(
+            creds.registries.get("foo").and_then(|r| r.token.clone()),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_cargo_credentials_empty() {
+        let sample = "";
+        let creds = toml::from_str::<CargoCredentials>(sample).unwrap();
+        assert_eq!(creds.registry.and_then(|r| r.token), None);
+        assert_eq!(
+            creds.registries.get("my").and_then(|r| r.token.clone()),
+            None
+        );
+        assert_eq!(
+            creds.registries.get("foo").and_then(|r| r.token.clone()),
+            None
+        );
+    }
 }

--- a/crates/cargo_utils/src/registry.rs
+++ b/crates/cargo_utils/src/registry.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use secrecy::SecretString;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -96,72 +95,6 @@ pub fn registry_url(manifest_path: &Path, registry: Option<&str>) -> anyhow::Res
     Ok(registry_url)
 }
 
-pub fn registry_token(registry: &Option<String>) -> anyhow::Result<Option<SecretString>> {
-    let mut token = registry_token_from_env(registry);
-    if token.is_none() {
-        token = registry_token_from_credential_file(registry)?;
-    }
-    Ok(token)
-}
-
-/// Read credentials for a specific registry using environment variables.
-/// <https://doc.rust-lang.org/cargo/reference/registry-authentication.html#cargotoken>
-pub fn registry_token_from_env(registry: &Option<String>) -> Option<SecretString> {
-    let token = if let Some(r) = registry {
-        let env_var = format!("CARGO_REGISTRIES_{}_TOKEN", r.to_uppercase());
-        std::env::var(env_var)
-    } else {
-        std::env::var("CARGO_REGISTRY_TOKEN")
-    };
-    token.ok().map(SecretString::new)
-}
-
-/// Read credentials for a specific registry using file cargo/credentials.toml.
-/// <https://doc.rust-lang.org/cargo/reference/config.html#credentials>
-pub fn registry_token_from_credential_file(
-    registry: &Option<String>,
-) -> anyhow::Result<Option<SecretString>> {
-    let credentials = read_cargo_credentials()?;
-    let token = credentials
-        .and_then(|c| {
-            let token: Option<RegistryToken> = if let Some(r) = registry {
-                c.registries.get(r).cloned()
-            } else {
-                c.registry.as_ref().cloned()
-            };
-            token
-        })
-        .and_then(|r| r.token.clone())
-        .map(SecretString::new);
-    Ok(token)
-}
-
-fn read_cargo_credentials() -> anyhow::Result<Option<CargoCredentials>> {
-    let credentials_path = credentials_path()?;
-    let credentials = if let Some(credentials_path) = credentials_path {
-        let content = fs_err::read_to_string(&credentials_path)
-            .context("failed to read cargo credentials file")?;
-        let credentials = toml::from_str::<CargoCredentials>(&content)
-            .context("Invalid cargo credentials file")?;
-        Some(credentials)
-    } else {
-        None
-    };
-    Ok(credentials)
-}
-
-fn credentials_path() -> anyhow::Result<Option<PathBuf>> {
-    let cargo_home = cargo_home()?;
-    let mut path = cargo_home.join("credentials.toml");
-    if !path.exists() {
-        path = cargo_home.join("credentials");
-    }
-    if !path.exists() {
-        return Ok(None);
-    }
-    Ok(Some(path))
-}
-
 #[derive(Debug, Deserialize)]
 struct CargoConfig {
     #[serde(default)]
@@ -182,20 +115,7 @@ struct Registry {
     index: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Default, PartialEq)]
-struct CargoCredentials {
-    #[serde(default)]
-    registry: Option<RegistryToken>,
-    #[serde(default)]
-    registries: HashMap<String, RegistryToken>,
-}
-
-#[derive(Debug, Deserialize, Default, PartialEq, Clone)]
-struct RegistryToken {
-    token: Option<String>,
-}
-
-fn cargo_home() -> anyhow::Result<PathBuf> {
+pub fn cargo_home() -> anyhow::Result<PathBuf> {
     let default_cargo_home = dirs::home_dir()
         .map(|x| x.join(".cargo"))
         .context("Failed to read home directory")?;
@@ -203,69 +123,4 @@ fn cargo_home() -> anyhow::Result<PathBuf> {
         .map(PathBuf::from)
         .unwrap_or(default_cargo_home);
     Ok(cargo_home)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_cargo_credentials_both() {
-        let sample = r#"
-            [registry]
-            token = "aaaa"   # Access token for crates.io
-
-            [registries.my]
-            token = "bbb"   # Access token for the named registry
-        "#;
-        let creds = toml::from_str::<CargoCredentials>(sample).unwrap();
-        assert_eq!(
-            creds.registry.and_then(|r| r.token),
-            Some("aaaa".to_string())
-        );
-        assert_eq!(
-            creds.registries.get("my").and_then(|r| r.token.clone()),
-            Some("bbb".to_string())
-        );
-        assert_eq!(
-            creds.registries.get("foo").and_then(|r| r.token.clone()),
-            None
-        );
-    }
-
-    #[test]
-    fn test_parse_cargo_credentials_cratesio_only() {
-        let sample = r#"
-            [registry]
-            token = "aaaa"   # Access token for crates.io
-        "#;
-        let creds = toml::from_str::<CargoCredentials>(sample).unwrap();
-        assert_eq!(
-            creds.registry.and_then(|r| r.token),
-            Some("aaaa".to_string())
-        );
-        assert_eq!(
-            creds.registries.get("my").and_then(|r| r.token.clone()),
-            None
-        );
-        assert_eq!(
-            creds.registries.get("foo").and_then(|r| r.token.clone()),
-            None
-        );
-    }
-
-    #[test]
-    fn test_parse_cargo_credentials_empty() {
-        let sample = "";
-        let creds = toml::from_str::<CargoCredentials>(sample).unwrap();
-        assert_eq!(creds.registry.and_then(|r| r.token), None);
-        assert_eq!(
-            creds.registries.get("my").and_then(|r| r.token.clone()),
-            None
-        );
-        assert_eq!(
-            creds.registries.get("foo").and_then(|r| r.token.clone()),
-            None
-        );
-    }
 }

--- a/crates/cargo_utils/src/token.rs
+++ b/crates/cargo_utils/src/token.rs
@@ -83,7 +83,6 @@ struct RegistryToken {
     token: Option<String>,
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cargo_utils/src/token.rs
+++ b/crates/cargo_utils/src/token.rs
@@ -26,7 +26,7 @@ pub fn registry_token_from_env(registry: Option<&str>) -> Option<SecretString> {
     } else {
         std::env::var("CARGO_REGISTRY_TOKEN")
     };
-    token.ok().map(SecretString::new)
+    token.ok().map(|t| t.into())
 }
 
 /// Read credentials for a specific registry using file cargo/credentials.toml.
@@ -45,7 +45,7 @@ pub fn registry_token_from_credential_file(
             token
         })
         .and_then(|r| r.token.clone())
-        .map(SecretString::new);
+        .map(|t| t.into());
     Ok(token)
 }
 

--- a/crates/cargo_utils/src/token.rs
+++ b/crates/cargo_utils/src/token.rs
@@ -1,0 +1,150 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use anyhow::Context as _;
+use secrecy::SecretString;
+use serde::Deserialize;
+
+pub fn registry_token(registry: &Option<String>) -> anyhow::Result<Option<SecretString>> {
+    let mut token = registry_token_from_env(registry);
+    if token.is_none() {
+        token = registry_token_from_credential_file(registry)?;
+    }
+    Ok(token)
+}
+
+/// Read credentials for a specific registry using environment variables.
+/// <https://doc.rust-lang.org/cargo/reference/registry-authentication.html#cargotoken>
+pub fn registry_token_from_env(registry: &Option<String>) -> Option<SecretString> {
+    let token = if let Some(r) = registry {
+        let env_var = format!("CARGO_REGISTRIES_{}_TOKEN", r.to_uppercase());
+        std::env::var(env_var)
+    } else {
+        std::env::var("CARGO_REGISTRY_TOKEN")
+    };
+    token.ok().map(SecretString::new)
+}
+
+/// Read credentials for a specific registry using file cargo/credentials.toml.
+/// <https://doc.rust-lang.org/cargo/reference/config.html#credentials>
+pub fn registry_token_from_credential_file(
+    registry: &Option<String>,
+) -> anyhow::Result<Option<SecretString>> {
+    let credentials = read_cargo_credentials()?;
+    let token = credentials
+        .and_then(|c| {
+            let token: Option<RegistryToken> = if let Some(r) = registry {
+                c.registries.get(r).cloned()
+            } else {
+                c.registry.as_ref().cloned()
+            };
+            token
+        })
+        .and_then(|r| r.token.clone())
+        .map(SecretString::new);
+    Ok(token)
+}
+
+fn read_cargo_credentials() -> anyhow::Result<Option<CargoCredentials>> {
+    let credentials_path = credentials_path()?;
+    let credentials = if let Some(credentials_path) = credentials_path {
+        let content = fs_err::read_to_string(&credentials_path)
+            .context("failed to read cargo credentials file")?;
+        let credentials = toml::from_str::<CargoCredentials>(&content)
+            .context("Invalid cargo credentials file")?;
+        Some(credentials)
+    } else {
+        None
+    };
+    Ok(credentials)
+}
+
+fn credentials_path() -> anyhow::Result<Option<PathBuf>> {
+    let cargo_home = crate::cargo_home()?;
+    let mut path = cargo_home.join("credentials.toml");
+    if !path.exists() {
+        path = cargo_home.join("credentials");
+    }
+    if !path.exists() {
+        return Ok(None);
+    }
+    Ok(Some(path))
+}
+
+#[derive(Debug, Deserialize, Default, PartialEq)]
+struct CargoCredentials {
+    #[serde(default)]
+    registry: Option<RegistryToken>,
+    #[serde(default)]
+    registries: HashMap<String, RegistryToken>,
+}
+
+#[derive(Debug, Deserialize, Default, PartialEq, Clone)]
+struct RegistryToken {
+    token: Option<String>,
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_cargo_credentials_both() {
+        let sample = r#"
+            [registry]
+            token = "aaaa"   # Access token for crates.io
+
+            [registries.my]
+            token = "bbb"   # Access token for the named registry
+        "#;
+        let creds = toml::from_str::<CargoCredentials>(sample).unwrap();
+        assert_eq!(
+            creds.registry.and_then(|r| r.token),
+            Some("aaaa".to_string())
+        );
+        assert_eq!(
+            creds.registries.get("my").and_then(|r| r.token.clone()),
+            Some("bbb".to_string())
+        );
+        assert_eq!(
+            creds.registries.get("foo").and_then(|r| r.token.clone()),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_cargo_credentials_cratesio_only() {
+        let sample = r#"
+            [registry]
+            token = "aaaa"   # Access token for crates.io
+        "#;
+        let creds = toml::from_str::<CargoCredentials>(sample).unwrap();
+        assert_eq!(
+            creds.registry.and_then(|r| r.token),
+            Some("aaaa".to_string())
+        );
+        assert_eq!(
+            creds.registries.get("my").and_then(|r| r.token.clone()),
+            None
+        );
+        assert_eq!(
+            creds.registries.get("foo").and_then(|r| r.token.clone()),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_cargo_credentials_empty() {
+        let sample = "";
+        let creds = toml::from_str::<CargoCredentials>(sample).unwrap();
+        assert_eq!(creds.registry.and_then(|r| r.token), None);
+        assert_eq!(
+            creds.registries.get("my").and_then(|r| r.token.clone()),
+            None
+        );
+        assert_eq!(
+            creds.registries.get("foo").and_then(|r| r.token.clone()),
+            None
+        );
+    }
+}

--- a/crates/release_plz/src/args/release.rs
+++ b/crates/release_plz/src/args/release.rs
@@ -28,6 +28,8 @@ pub struct Release {
     #[arg(long)]
     registry: Option<String>,
     /// Token used to publish to the cargo registry.
+    /// Override the `CARGO_REGISTRY_TOKEN` environment variable, or the `CARGO_REGISTRIES_<NAME>_TOKEN`
+    /// environment variable, used for registry specified in the `registry` input variable.
     #[arg(long, value_parser = NonEmptyStringValueParser::new())]
     token: Option<String>,
     /// Perform all checks without uploading.

--- a/crates/release_plz/src/args/update.rs
+++ b/crates/release_plz/src/args/update.rs
@@ -52,7 +52,8 @@ pub struct Update {
     release_date: Option<String>,
     /// Registry where the packages are stored.
     /// The registry name needs to be present in the Cargo config.
-    /// If unspecified, crates.io is used.
+    /// If unspecified, the `publish` field of the package manifest is used.
+    /// If the `publish` field is empty, crates.io is used.
     #[arg(
         long,
         conflicts_with("registry_manifest_path"),

--- a/crates/release_plz_core/Cargo.toml
+++ b/crates/release_plz_core/Cargo.toml
@@ -31,6 +31,7 @@ fs-err = { workspace = true, features = ["tokio"] }
 git-cliff-core.workspace = true
 git-url-parse.workspace = true
 ignore.workspace = true
+itertools.workspace = true
 lazy_static.workspace = true
 parse-changelog.workspace = true
 rand.workspace = true

--- a/crates/release_plz_core/src/cargo.rs
+++ b/crates/release_plz_core/src/cargo.rs
@@ -12,7 +12,8 @@ use std::{
 };
 
 pub struct CargoRegistry {
-    /// name of the registry None means default 'crate.io'
+    /// Name of the registry.
+    /// [`Option::None`] means default 'crate.io'.
     pub name: Option<String>,
     pub index: CargoIndex,
 }

--- a/crates/release_plz_core/src/cargo.rs
+++ b/crates/release_plz_core/src/cargo.rs
@@ -11,6 +11,12 @@ use std::{
     time::{Duration, Instant},
 };
 
+pub struct CargoRegistry {
+    /// name of the registry None means default 'crate.io'
+    pub name: Option<String>,
+    pub index: CargoIndex,
+}
+
 pub enum CargoIndex {
     Git(GitIndex),
     Sparse(SparseIndex),

--- a/crates/release_plz_core/src/clone/source.rs
+++ b/crates/release_plz_core/src/clone/source.rs
@@ -1,11 +1,21 @@
 // Copied from [cargo-clone](https://github.com/JanLikar/cargo-clone/blob/89ba4da215663ffb3b8c93a674f3002937eafec4/cargo-clone-core/src/source.rs)
 
 use cargo::{core::SourceId, CargoResult, GlobalContext};
+use std::fmt;
 
 /// Where to clone the crate from.
 #[derive(Debug, Default, Clone)]
 pub struct ClonerSource {
     pub(crate) cargo_source: CargoSource,
+}
+
+impl fmt::Display for CargoSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CargoSource::CratesIo => write!(f, "crates.io"),
+            CargoSource::Registry(key) => write!(f, "{key}"),
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -170,6 +170,7 @@ impl ReleaseRequest {
         config.features.clone()
     }
 
+    /// Find the token to use for the given `registry` ([`Option::None`] means crates.io).
     fn find_registry_token(&self, registry: Option<&str>) -> anyhow::Result<Option<SecretString>> {
         if self.registry.as_deref() == registry {
             Ok(self

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -173,7 +173,7 @@ impl ReleaseRequest {
     fn find_registry_token(
         &self,
         registry: &Option<String>,
-    ) -> anyhow::Result<Option<secrecy::Secret<String>>> {
+    ) -> anyhow::Result<Option<SecretString>> {
         if self.registry == *registry {
             Ok(self
                 .token

--- a/crates/release_plz_core/src/download.rs
+++ b/crates/release_plz_core/src/download.rs
@@ -46,11 +46,14 @@ impl PackageDownloader {
 
     #[instrument]
     pub fn download(&self) -> anyhow::Result<Vec<Package>> {
-        info!("downloading packages from cargo registry");
         let source: ClonerSource = match &self.registry {
             Some(registry) => ClonerSource::registry(registry),
             None => ClonerSource::crates_io(),
         };
+        info!(
+            "downloading packages from cargo registry {}",
+            source.cargo_source
+        );
         let crates: Vec<Crate> = self
             .packages
             .iter()

--- a/crates/release_plz_core/src/registry_packages.rs
+++ b/crates/release_plz_core/src/registry_packages.rs
@@ -60,7 +60,7 @@ pub fn get_registry_packages(
                 })
                 .collect(),
         ),
-        None => {
+        Option::None => {
             let temp_dir = tempdir().context("failed to get a temporary directory")?;
             let local_packages_names: Vec<&str> =
                 local_packages.iter().map(|c| c.name.as_str()).collect();
@@ -68,6 +68,10 @@ pub fn get_registry_packages(
 
             let mut downloader = download::PackageDownloader::new(local_packages_names, directory);
             if let Some(registry) = registry {
+                downloader = downloader.with_registry(registry.to_string());
+            } else if let Some(registry) = local_packages.iter().find_map(|p| p.publish.as_ref().and_then(|p| p.first())) {
+                // FIXME download each package from the registry defined in the Cargo.toml `publish` field.
+                // HACK use the first registry in the `publish` field of any of the packages. (expect that it's the same for all packages)
                 downloader = downloader.with_registry(registry.to_string());
             }
             let registry_packages = downloader

--- a/crates/release_plz_core/src/registry_packages.rs
+++ b/crates/release_plz_core/src/registry_packages.rs
@@ -65,13 +65,13 @@ pub fn get_registry_packages(
             let temp_dir = tempdir().context("failed to get a temporary directory")?;
             let directory = temp_dir.as_ref().to_str().context("invalid tempdir path")?;
 
-            // select one registry from where to download the package.
-            // the selected registry is defined from cli and fallback to the Cargo.toml `publish` field.
-            // HACK use the first registry in the `publish`
+            // Find the registry from where to download each package.
             let packages_grouped_by_registry = local_packages.iter().chunk_by(|p| {
+                // If registry is not provided, fallback to the Cargo.toml `publish` field.
                 registry.or_else(|| {
                     p.publish
                         .as_ref()
+                        // Use the first registry in the `publish` field.
                         .and_then(|p| p.first())
                         .map(|x| x.as_str())
                 })

--- a/crates/release_plz_core/src/registry_packages.rs
+++ b/crates/release_plz_core/src/registry_packages.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use cargo_metadata::{camino::Utf8Path, Package};
 use git_cmd::git_in_dir;
+use itertools::Itertools;
 use tempfile::{tempdir, TempDir};
 
 use crate::{cargo_vcs_info, download, next_ver, PackagePath};
@@ -62,21 +63,30 @@ pub fn get_registry_packages(
         ),
         Option::None => {
             let temp_dir = tempdir().context("failed to get a temporary directory")?;
-            let local_packages_names: Vec<&str> =
-                local_packages.iter().map(|c| c.name.as_str()).collect();
             let directory = temp_dir.as_ref().to_str().context("invalid tempdir path")?;
 
-            let mut downloader = download::PackageDownloader::new(local_packages_names, directory);
-            if let Some(registry) = registry {
-                downloader = downloader.with_registry(registry.to_string());
-            } else if let Some(registry) = local_packages.iter().find_map(|p| p.publish.as_ref().and_then(|p| p.first())) {
-                // FIXME download each package from the registry defined in the Cargo.toml `publish` field.
-                // HACK use the first registry in the `publish` field of any of the packages. (expect that it's the same for all packages)
-                downloader = downloader.with_registry(registry.to_string());
+            // download packages from the registry defined in cli and fallback to the Cargo.toml `publish` field.
+            // HACK use the first registry in the `publish`
+            let mut registry_packages: Vec<Package> = vec![];
+            for (registry, packages) in &local_packages.iter().chunk_by(|p| {
+                registry.or_else(|| {
+                    p.publish
+                        .as_ref()
+                        .and_then(|p| p.first())
+                        .map(|x| x.as_str())
+                })
+            }) {
+                let packages_names: Vec<&str> = packages.map(|p| p.name.as_str()).collect();
+                let mut downloader = download::PackageDownloader::new(packages_names, directory);
+                if let Some(registry) = registry {
+                    downloader = downloader.with_registry(registry.to_string());
+                }
+                registry_packages.extend(
+                    downloader
+                        .download()
+                        .context("failed to download packages")?,
+                );
             }
-            let registry_packages = downloader
-                .download()
-                .context("failed to download packages")?;
 
             // After downloading the package, we initialize a git repo in the package.
             // This is because if cargo doesn't find a git repo in the package, it doesn't

--- a/crates/release_plz_core/src/registry_packages.rs
+++ b/crates/release_plz_core/src/registry_packages.rs
@@ -61,7 +61,7 @@ pub fn get_registry_packages(
                 })
                 .collect(),
         ),
-        Option::None => {
+        None => {
             let temp_dir = tempdir().context("failed to get a temporary directory")?;
             let directory = temp_dir.as_ref().to_str().context("invalid tempdir path")?;
 

--- a/website/docs/github/quickstart.md
+++ b/website/docs/github/quickstart.md
@@ -213,7 +213,8 @@ The GitHub action accepts the following input variables:
   `release`. (By default it runs both commands).
 - `registry`: Registry where the packages are stored.
   The registry name needs to be present in the Cargo config.
-  If unspecified, crates.io is used. (Defaults to crates.io).
+  If unspecified, the `publish` field of the package manifest is used.
+  If the `publish` field is empty, crates.io is used.
 - `manifest_path`: Path to the Cargo.toml of the project you want to update.
   Both Cargo workspaces and single packages are supported. (Defaults to the root
   directory).
@@ -221,6 +222,8 @@ The GitHub action accepts the following input variables:
 - `config`: Release-plz config file location. (Defaults to
   `release-plz.toml` or `.release-plz.toml`).
 - `token`: Token used to publish to the cargo registry.
+  Override the `CARGO_REGISTRY_TOKEN` environment variable, or the `CARGO_REGISTRIES_<NAME>_TOKEN`
+  environment variable, used for registry specified in the `registry` input variable.
 - `backend`: Forge backend. Valid values: `github`, `gitea`. (Defaults to `github`).
 
 You can specify the input variables by using the `with` keyword.


### PR DESCRIPTION
tokens are read from:
- cli's argument `--token`
- environment variables (ala `cargo:token`)
- file `cargo/credentials.toml` (ala `cargo:token`)

Also registry + token is read for each package because:
- each package could be published to a different registry, 
- `--registry` and `--token` could be unspecified (in this case use info from `Cargo.toml` ,...)

FIX #1659
