### PR TITLE
fix: fallback to http 1.1 when http2 is not supported on fetching sparse metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ pretty_assertions = "1.4.0"
 rayon = "1.10.0"
 rand = "0.8.5"
 regex = "1.10.6"
-reqwest = "0.12.7"
+reqwest = { version = "0.12.7", features = ["json", "native-tls-alpn"] }
 reqwest-middleware = { version = "0.3.3", features = ["json"] }
 reqwest-retry = "0.6.1"
 schemars = { version = "0.8.21", features = ["url"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ pretty_assertions = "1.4.0"
 rayon = "1.10.0"
 rand = "0.8.5"
 regex = "1.10.6"
-reqwest = { version = "0.12.7", features = ["json", "native-tls-alpn"] }
+reqwest = "0.12.7"
 reqwest-middleware = { version = "0.3.3", features = ["json"] }
 reqwest-retry = "0.6.1"
 schemars = { version = "0.8.21", features = ["url"] }

--- a/crates/release_plz_core/src/cargo.rs
+++ b/crates/release_plz_core/src/cargo.rs
@@ -118,7 +118,7 @@ async fn fetch_sparse_metadata(
     if let Err(ref e) = res {
         match e.downcast_ref::<reqwest::Error>() {
             Some(e) if e.is_connect() => {
-                // TODO log info about fallbacking ? on connection error
+                debug!("HTTP/2 sparse index request failed, trying HTTP/1.1");
                 res = request_for_sparse_metadata(index, crate_name, token, Version::HTTP_11).await;
             }
             _ => (),
@@ -148,8 +148,8 @@ async fn request_for_sparse_metadata(
     token: &Option<SecretString>,
     http_version: Version,
 ) -> anyhow::Result<reqwest::Response> {
-    // make_cache_request force version to HTTP_2
     let mut req = index.make_cache_request(crate_name)?;
+    // override default http version
     req = req.version(http_version);
     let (parts, _) = req.body(())?.into_parts();
     let req = http::Request::from_parts(parts, vec![]);

--- a/crates/release_plz_core/src/cargo.rs
+++ b/crates/release_plz_core/src/cargo.rs
@@ -165,17 +165,18 @@ async fn request_for_sparse_metadata(
         req.headers_mut()
             .insert(header::AUTHORIZATION, authorization);
     }
-    
-    let mut client_builder = reqwest::ClientBuilder::new()
-        .gzip(true);
-    if ! force_http11 {
+
+    let mut client_builder = reqwest::ClientBuilder::new().gzip(true);
+    if !force_http11 {
         client_builder = client_builder.http2_prior_knowledge();
     }
 
     let client = client_builder.build()?;
-    client.execute(req).await.context("request_for_sparse_metadata")
+    client
+        .execute(req)
+        .await
+        .context("request_for_sparse_metadata")
 }
-
 
 pub async fn wait_until_published(
     index: &mut CargoIndex,


### PR DESCRIPTION

FIX #1668
