### PR TITLE
fix: reset git config (if issue with global config)

### DIFF
--- a/crates/git_cmd/src/test_fixture.rs
+++ b/crates/git_cmd/src/test_fixture.rs
@@ -14,6 +14,7 @@ impl Repo {
         // configure author
         git_in_dir(directory, &["config", "user.name", "author_name"]).unwrap();
         git_in_dir(directory, &["config", "user.email", "author@example.com"]).unwrap();
+        git_in_dir(directory, &["config", "commit.gpgsign", "false"]).unwrap();
 
         fs_err::write(directory.join("README.md"), "# my awesome project").unwrap();
         git_in_dir(directory, &["add", "."]).unwrap();


### PR DESCRIPTION
small change to avoid an error during test with git, when the git's local configuration is `commit.gpgsign = true` but the  `user` defined in the test doesn't have an ssh or gpg private key.
