### PR TITLE
Enable default features for url crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ toml_edit = { version = "0.22.20" }
 tracing = "0.1.40"
 tracing-log = "0.2.0"
 tracing-subscriber = "0.3.18"
-url = { version = "2.5.2", default-features = false }
+url = "2.5.2"
 walkdir = "2.5.0"
 wiremock = "0.6.1"
 


### PR DESCRIPTION
In order to make the rust-url compatible with no_std, the crate needs to introduce a `std` feature and make it default. See https://github.com/servo/rust-url/pull/831.

To reduce impact, downstream libraries should leave url's default features enabled (no other features are currently `default`).