### PR TITLE
fix: Disable changelog in PR body if it goes over github character limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ zero_sized_map_values = "warn"
 
 # Allowing optional lints has no effect, but we list them to
 # make clear that we reviewed them and we decided to allow them
-decimal_literal_representation = "warn"
+decimal_literal_representation = "allow"
 map_unwrap_or = "allow"
 needless_raw_string_hashes = "allow"
 redundant_else = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ cast_lossless = "warn"
 cast_possible_wrap = "warn"
 cast_precision_loss = "warn"
 cast_sign_loss = "warn"
-decimal_literal_representation = "warn"
 default_trait_access = "warn"
 doc_markdown = "warn"
 exit = "warn"
@@ -128,6 +127,7 @@ zero_sized_map_values = "warn"
 
 # Allowing optional lints has no effect, but we list them to
 # make clear that we reviewed them and we decided to allow them
+decimal_literal_representation = "warn"
 map_unwrap_or = "allow"
 needless_raw_string_hashes = "allow"
 redundant_else = "allow"

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -110,7 +110,7 @@ fn pr_body(
         // If it's not, give up trying to fail gracefully by truncating it to the nearest valid UTF-8 boundary.
         // A grapheme cluster may be cut in half in the process.
         if formatted.chars().count() > MAX_BODY_LEN {
-            tracing::warn!("PR body is still longer than 65536 characters. Truncating as is.");
+            tracing::warn!("PR body is still longer than {MAX_BODY_LEN} characters. Truncating as is.");
             formatted = formatted.chars().take(MAX_BODY_LEN).collect();
         }
     }

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -85,7 +85,6 @@ fn pr_body(
     project_contains_multiple_pub_packages: bool,
 ) -> String {
     /// The Github API allows a max of 65536 characters in the body field when trying to create a new PR
-    #[allow(clippy::decimal_literal_representation)]
     const MAX_BODY_LEN: usize = 65536;
 
     let header = "## 🤖 New release";

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -103,14 +103,18 @@ fn pr_body(
 
     // Make sure we don't go over the Github API's limit for PR body size
     if formatted.chars().count() > MAX_BODY_LEN {
-        tracing::info!("PR body is longer than {MAX_BODY_LEN} characters. Omitting full changelog.");
+        tracing::info!(
+            "PR body is longer than {MAX_BODY_LEN} characters. Omitting full changelog."
+        );
         formatted = format!("{header}{summary}\n{footer}");
 
         // Make extra sure the body is short enough.
         // If it's not, give up trying to fail gracefully by truncating it to the nearest valid UTF-8 boundary.
         // A grapheme cluster may be cut in half in the process.
         if formatted.chars().count() > MAX_BODY_LEN {
-            tracing::warn!("PR body is still longer than {MAX_BODY_LEN} characters. Truncating as is.");
+            tracing::warn!(
+                "PR body is still longer than {MAX_BODY_LEN} characters. Truncating as is."
+            );
             formatted = formatted.chars().take(MAX_BODY_LEN).collect();
         }
     }

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -103,7 +103,7 @@ fn pr_body(
 
     // Make sure we don't go over the Github API's limit for PR body size
     if formatted.chars().count() > MAX_BODY_LEN {
-        tracing::warn!("PR body is longer than 65536 characters. Omitting full changelog.");
+        tracing::info!("PR body is longer than {MAX_BODY_LEN} characters. Omitting full changelog.");
         formatted = format!("{header}{summary}\n{footer}");
 
         // Make extra sure the body is short enough.

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -84,7 +84,7 @@ fn pr_body(
     packages_to_update: &PackagesUpdate,
     project_contains_multiple_pub_packages: bool,
 ) -> String {
-    /// The Github API allows a max of 65536 bytes in the body field when trying to create a new PR
+    /// The Github API allows a max of 65536 characters in the body field when trying to create a new PR
     #[allow(clippy::decimal_literal_representation)]
     const MAX_BODY_LEN: usize = 65536;
 
@@ -103,21 +103,16 @@ fn pr_body(
     let mut formatted = format!("{header}{summary}\n{changes}\n{footer}");
 
     // Make sure we don't go over the Github API's limit for PR body size
-    if formatted.len() >= MAX_BODY_LEN {
-        tracing::warn!("PR body is longer than 65535 bytes. Omitting full changelog.");
+    if formatted.chars().count() > MAX_BODY_LEN {
+        tracing::warn!("PR body is longer than 65536 characters. Omitting full changelog.");
         formatted = format!("{header}{summary}\n{footer}");
 
         // Make extra sure the body is short enough.
         // If it's not, give up trying to fail gracefully by truncating it to the nearest valid UTF-8 boundary.
         // A grapheme cluster may be cut in half in the process.
-        if formatted.len() >= MAX_BODY_LEN {
-            tracing::warn!("PR body is still longer than 65535 bytes. Truncating as is.");
-            let mut str_end = MAX_BODY_LEN - 1;
-            while !formatted.is_char_boundary(str_end) {
-                str_end -= 1;
-            }
-
-            formatted.truncate(str_end);
+        if formatted.chars().count() > MAX_BODY_LEN {
+            tracing::warn!("PR body is still longer than 65536 characters. Truncating as is.");
+            formatted = formatted.chars().take(MAX_BODY_LEN).collect();
         }
     }
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->
As described in #1715, some workspaces may have enough changes to publish that trying to open a PR fails because the body is too long. This PR adds a configuration option to disable adding the changelog to the PR body, leaving only the changes summary.

### Alternatives

One alternative would be to let the user specify whether they want to include the changelog in the PR body for each package. Another would be to forgo adding a user option and automatically fail over to the summary-only body if we detect that the body is too long.

Closes #1715.

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
