### PR TITLE
feat: add `pr_branch_prefix` option to configure branch prefix for release-pr (#1728)

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -50,6 +50,7 @@
         "git_release_type": null,
         "git_tag_enable": null,
         "git_tag_name": null,
+        "pr_branch_prefix": null,
         "pr_draft": false,
         "pr_labels": [],
         "publish": null,
@@ -598,6 +599,14 @@
         "git_tag_name": {
           "title": "Git Tag Name",
           "description": "Tera template of the git tag name created by release-plz.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pr_branch_prefix": {
+          "title": "PR Branch Prefix",
+          "description": "Prefix for the PR Branch",
           "type": [
             "string",
             "null"

--- a/crates/release_plz/src/args/release.rs
+++ b/crates/release_plz/src/args/release.rs
@@ -133,6 +133,8 @@ impl Release {
 
         req = config.fill_release_config(self.allow_dirty, self.no_verify, req);
 
+        req = req.with_branch_prefix(config.workspace.pr_branch_prefix.clone());
+
         Ok(req)
     }
 }

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -133,6 +133,9 @@ pub struct Workspace {
     /// Labels to add to the release PR.
     #[serde(default)]
     pub pr_labels: Vec<String>,
+    /// # PR Branch Prefix
+    /// Prefix for the PR Branch
+    pub pr_branch_prefix: Option<String>,
     /// # Publish Timeout
     /// Timeout for the publishing process
     pub publish_timeout: Option<String>,
@@ -429,6 +432,7 @@ mod tests {
         git_release_enable = true
         git_release_type = "prod"
         git_release_draft = false
+        pr_branch_prefix = "f-"
         publish_timeout = "10m"
         release_commits = "^feat:"
     "#;
@@ -456,6 +460,7 @@ mod tests {
                 },
                 pr_draft: false,
                 pr_labels: vec![],
+                pr_branch_prefix: Some("f-".to_string()),
                 publish_timeout: Some("10m".to_string()),
                 release_commits: Some("^feat:".to_string()),
                 release_always: None,
@@ -563,6 +568,7 @@ mod tests {
                 repo_url: Some("https://github.com/MarcoIeni/release-plz".parse().unwrap()),
                 pr_draft: false,
                 pr_labels: vec!["label1".to_string()],
+                pr_branch_prefix: Some("f-".to_string()),
                 packages_defaults: PackageConfig {
                     semver_check: None,
                     changelog_update: true.into(),
@@ -607,6 +613,7 @@ mod tests {
             changelog_config = "../git-cliff.toml"
             pr_draft = false
             pr_labels = ["label1"]
+            pr_branch_prefix = "f-"
             publish_timeout = "10m"
             repo_url = "https://github.com/MarcoIeni/release-plz"
             release_commits = "^feat:"

--- a/crates/release_plz/src/main.rs
+++ b/crates/release_plz/src/main.rs
@@ -40,10 +40,9 @@ async fn run(args: CliArgs) -> anyhow::Result<()> {
             let cargo_metadata = cmd_args.update.cargo_metadata()?;
             let config = cmd_args.update.config()?;
             let update_request = cmd_args.update.update_request(&config, cargo_metadata)?;
-            let cmd_args_output: Option<OutputType> = cmd_args.output;
             let request = get_release_pr_req(&config, update_request)?;
             let release_pr = release_plz_core::release_pr(&request).await?;
-            if let Some(output_type) = cmd_args_output {
+            if let Some(output_type) = cmd_args.output {
                 let prs = match release_pr {
                     Some(pr) => vec![pr],
                     None => vec![],

--- a/crates/release_plz/src/main.rs
+++ b/crates/release_plz/src/main.rs
@@ -38,12 +38,14 @@ async fn run(args: CliArgs) -> anyhow::Result<()> {
         Command::ReleasePr(cmd_args) => {
             let cargo_metadata = cmd_args.update.cargo_metadata()?;
             let config = cmd_args.update.config()?;
+            let pr_branch_prefix = config.workspace.pr_branch_prefix.clone();
             let pr_labels = config.workspace.pr_labels.clone();
             let pr_draft = config.workspace.pr_draft;
             let update_request = cmd_args.update.update_request(config, cargo_metadata)?;
             let request = ReleasePrRequest::new(update_request)
                 .mark_as_draft(pr_draft)
-                .with_labels(pr_labels);
+                .with_labels(pr_labels)
+                .with_branch_prefix(pr_branch_prefix);
             let release_pr = release_plz_core::release_pr(&request).await?;
             if let Some(output_type) = cmd_args.output {
                 let prs = match release_pr {

--- a/crates/release_plz/tests/all/helpers/test_context.rs
+++ b/crates/release_plz/tests/all/helpers/test_context.rs
@@ -9,7 +9,7 @@ use cargo_metadata::{
 use cargo_utils::LocalManifest;
 use git_cmd::Repo;
 use release_plz_core::{
-    fs_utils::Utf8TempDir, GitBackend, GitClient, GitPr, Gitea, RepoUrl, BRANCH_PREFIX,
+    fs_utils::Utf8TempDir, GitBackend, GitClient, GitPr, Gitea, RepoUrl, DEFAULT_BRANCH_PREFIX,
 };
 use secrecy::SecretString;
 
@@ -148,7 +148,10 @@ impl TestContext {
     }
 
     pub async fn opened_release_prs(&self) -> Vec<GitPr> {
-        self.git_client.opened_prs(BRANCH_PREFIX).await.unwrap()
+        self.git_client
+            .opened_prs(DEFAULT_BRANCH_PREFIX)
+            .await
+            .unwrap()
     }
 
     pub fn write_release_plz_toml(&self, content: &str) {

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -20,8 +20,8 @@ use crate::{
     git::backend::GitClient,
     pr_parser::{prs_from_text, Pr},
     release_order::release_order,
-    GitBackend, PackagePath, Project, ReleaseMetadata, ReleaseMetadataBuilder, BRANCH_PREFIX,
-    CHANGELOG_FILENAME,
+    GitBackend, PackagePath, Project, ReleaseMetadata, ReleaseMetadataBuilder, CHANGELOG_FILENAME,
+    DEFAULT_BRANCH_PREFIX,
 };
 
 #[derive(Debug)]
@@ -67,7 +67,7 @@ impl ReleaseRequest {
             packages_config: PackagesConfig::default(),
             publish_timeout: minutes_30,
             release_always: true,
-            branch_prefix: BRANCH_PREFIX.to_string(),
+            branch_prefix: DEFAULT_BRANCH_PREFIX.to_string(),
         }
     }
 

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -20,8 +20,8 @@ use crate::{
     git::backend::GitClient,
     pr_parser::{prs_from_text, Pr},
     release_order::release_order,
-    GitBackend, PackagePath, Project, ReleaseMetadata, ReleaseMetadataBuilder, CHANGELOG_FILENAME,
-    DEFAULT_BRANCH_PREFIX,
+    GitBackend, PackagePath, Project, ReleaseMetadata, ReleaseMetadataBuilder, Remote,
+    CHANGELOG_FILENAME, DEFAULT_BRANCH_PREFIX,
 };
 
 #[derive(Debug)]

--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -50,6 +50,8 @@ pub struct ReleaseRequest {
     packages_config: PackagesConfig,
     /// publish timeout
     publish_timeout: Duration,
+    /// PR Branch Prefix
+    branch_prefix: String,
 }
 
 impl ReleaseRequest {
@@ -65,6 +67,7 @@ impl ReleaseRequest {
             packages_config: PackagesConfig::default(),
             publish_timeout: minutes_30,
             release_always: true,
+            branch_prefix: BRANCH_PREFIX.to_string(),
         }
     }
 
@@ -110,6 +113,13 @@ impl ReleaseRequest {
 
     pub fn with_release_always(mut self, release_always: bool) -> Self {
         self.release_always = release_always;
+        self
+    }
+
+    pub fn with_branch_prefix(mut self, pr_branch_prefix: Option<String>) -> Self {
+        if let Some(branch_prefix) = pr_branch_prefix {
+            self.branch_prefix = branch_prefix;
+        }
         self
     }
 
@@ -558,8 +568,9 @@ async fn should_release(
     }
     let last_commit = repo.current_commit_hash()?;
     let prs = git_client.associated_prs(&last_commit).await?;
-    let is_current_commit_from_release_pr =
-        prs.iter().any(|pr| pr.branch().starts_with(BRANCH_PREFIX));
+    let is_current_commit_from_release_pr = prs
+        .iter()
+        .any(|pr| pr.branch().starts_with(&input.branch_prefix));
     if !is_current_commit_from_release_pr {
         info!("skipping release: current commit is not from a release PR");
     }

--- a/crates/release_plz_core/src/lib.rs
+++ b/crates/release_plz_core/src/lib.rs
@@ -36,6 +36,6 @@ pub use git::gitlab_client::GitLab;
 pub use next_ver::*;
 pub use package_compare::*;
 pub use package_path::*;
-pub use pr::BRANCH_PREFIX;
+pub use pr::DEFAULT_BRANCH_PREFIX;
 pub use project::*;
 pub use repo_url::*;

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -19,9 +19,10 @@ impl Pr {
         default_branch: &str,
         packages_to_update: &PackagesUpdate,
         project_contains_multiple_pub_packages: bool,
+        branch_prefix: &str,
     ) -> Self {
         Self {
-            branch: release_branch(),
+            branch: release_branch(branch_prefix),
             base_branch: default_branch.to_string(),
             title: pr_title(packages_to_update, project_contains_multiple_pub_packages),
             body: pr_body(packages_to_update, project_contains_multiple_pub_packages),
@@ -41,13 +42,13 @@ impl Pr {
     }
 }
 
-fn release_branch() -> String {
+fn release_branch(prefix: &str) -> String {
     let now = chrono::offset::Utc::now();
     // Convert to a string of format "2018-01-26T18:30:09Z".
     let now = now.to_rfc3339_opts(SecondsFormat::Secs, true);
     // ':' is not a valid character for a branch name.
     let now = now.replace(':', "-");
-    format!("{BRANCH_PREFIX}{now}")
+    format!("{prefix}{now}")
 }
 
 fn pr_title(

--- a/crates/release_plz_core/src/pr.rs
+++ b/crates/release_plz_core/src/pr.rs
@@ -1,7 +1,7 @@
 use crate::PackagesUpdate;
 use chrono::SecondsFormat;
 
-pub const BRANCH_PREFIX: &str = "release-plz-";
+pub const DEFAULT_BRANCH_PREFIX: &str = "release-plz-";
 pub const OLD_BRANCH_PREFIX: &str = "release-plz/";
 
 #[derive(Debug)]

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -318,8 +318,9 @@ Where:
 
 Prefix for the release PR branch. By default, it's set to: `release-plz-`
 
-:::warning 
+:::warning
 Before changing the release-plz branch you should close the old release PR
+:::
 
 #### The `pr_draft` field
 
@@ -428,6 +429,7 @@ release = false
 
 - If true, release-plz release will try to release your packages every time you run it
   (e.g. on every commit in the main branch). *(Default)*.
+  
   :::warning
   In this case, every package is published as soon as you commit it.
   :::

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -21,6 +21,7 @@ changelog_config = "config/git-cliff.toml" # use a custom git-cliff configuratio
 changelog_update = false # disable changelog updates
 dependencies_update = true # update dependencies with `cargo update`
 git_release_enable = false # disable GitHub/Gitea releases
+pr_branch_prefix = "release-plz-" # PR branch prefix
 pr_labels = ["release"] # add the `release` label to the release Pull Request
 publish_allow_dirty = true # add `--allow-dirty` to `cargo publish`
 semver_check = false # disable API breaking changes checks
@@ -69,6 +70,7 @@ the following sections:
   - [`git_release_latest`](#the-git_release_latest-field) — Publish git release as latest.
   - [`git_tag_enable`](#the-git_tag_enable-field) — Enable git tag.
   - [`git_tag_name`](#the-git_tag_name-field) — Customize git tag pattern.
+  - [`pr_branch_prefix`](#the-pr_branch_prefix-field) — Release PR branch prefix.
   - [`pr_draft`](#the-pr_draft-field) — Open the release Pull Request as a draft.
   - [`pr_labels`](#the-pr_labels-field) — Add labels to the release Pull Request.
   - [`publish`](#the-publish-field) — Publish to cargo registry.
@@ -130,6 +132,7 @@ changelog_config = "config/git-cliff.toml"
 changelog_update = false
 dependencies_update = true # update dependencies with `cargo update`
 git_release_enable = true
+pr_branch_prefix = "feat-pr-" # Release PR branch prefix
 publish_allow_dirty = true
 publish_no_verify = false
 repo_url = "https://github.com/<owner>/<repo>"
@@ -289,6 +292,13 @@ Where:
 
 - `{{ package }}` is the name of the package.
 - `{{ version }}` is the new version of the package.
+
+#### The `pr_branch_prefix` field
+
+Prefix for the release PR branch. By default, it's set to: `release-plz-`
+
+:::warning 
+Before changing the release-plz branch you should close the old release PR
 
 #### The `pr_draft` field
 

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -319,7 +319,7 @@ Where:
 Prefix for the release PR branch. By default, it's set to: `release-plz-`
 
 :::warning
-Before changing the release-plz branch you should close the old release PR
+Before changing the release-plz branch you should close the old release PR.
 :::
 
 #### The `pr_draft` field
@@ -429,7 +429,7 @@ release = false
 
 - If true, release-plz release will try to release your packages every time you run it
   (e.g. on every commit in the main branch). *(Default)*.
-  
+
   :::warning
   In this case, every package is published as soon as you commit it.
   :::


### PR DESCRIPTION
Fix for Issue # 1728  - Changes related to configuring the PR Branch Prefix in release-plz.toml (defaults to the current prefix "release-plz-" if none specified)
