### PR TITLE
fix: typo in CLI log level help

### DIFF
--- a/crates/release_plz/src/args/mod.rs
+++ b/crates/release_plz/src/args/mod.rs
@@ -30,7 +30,7 @@ pub struct CliArgs {
     #[command(subcommand)]
     pub command: Command,
     /// Print source location and additional information in logs.
-    /// To change the log level, use the `RUST_FLAG` environment variable.
+    /// To change the log level, use the `RUST_LOG` environment variable.
     #[arg(short, long, global = true)]
     pub verbose: bool,
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

There was a small typo in command-line help about log level adjustment (correct environment variable is `RUST_LOG`. 

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
