### PR TITLE
fix: revert Cargo.lock changes after running `cargo package`

### DIFF
--- a/crates/release_plz_core/src/next_ver.rs
+++ b/crates/release_plz_core/src/next_ver.rs
@@ -938,8 +938,9 @@ impl Updater<'_> {
 
             // Check if files changed in git commit belong to the current package.
             // This is required because a package can contain another package in a subdirectory.
-            let are_changed_files_in_pkg =
-                || are_changed_files_in_package(package_path, repository, &current_commit_hash);
+            let are_changed_files_in_pkg = || {
+                self.are_changed_files_in_package(package_path, repository, &current_commit_hash)
+            };
 
             if let Some(registry_package) = registry_package {
                 debug!(
@@ -980,7 +981,7 @@ impl Updater<'_> {
                     info!("{}: the local package has already a different version with respect to the registry package, so release-plz will not update it", package.name);
                     diff.set_version_unpublished();
                     break;
-                } else if are_changed_files_in_pkg() {
+                } else if are_changed_files_in_pkg()? {
                     debug!("packages are different");
                     // At this point of the git history, the two packages are different,
                     // which means that this commit is not present in the published package.
@@ -989,7 +990,7 @@ impl Updater<'_> {
                         current_commit_message.clone(),
                     ));
                 }
-            } else if are_changed_files_in_pkg() {
+            } else if are_changed_files_in_pkg()? {
                 diff.commits.push(Commit::new(
                     current_commit_hash,
                     current_commit_message.clone(),
@@ -1109,23 +1110,40 @@ impl Updater<'_> {
         };
         Ok(next_version)
     }
-}
 
-/// `hash` is only used for logging purposes.
-fn are_changed_files_in_package(package_path: &Utf8Path, repository: &Repo, hash: &str) -> bool {
-    let Ok(package_files) = get_package_files(package_path, repository).inspect_err(|e| {
-        debug!("failed to get package files at commit {hash}: {e:?}");
-    }) else {
-        // `cargo package` can fail if the package doesn't contain a Cargo.toml file yet.
-        return true;
-    };
-    let Ok(changed_files) = repository.files_of_current_commit().inspect_err(|e| {
-        warn!("failed to get changed files of commit {hash}: {e:?}");
-    }) else {
-        // Assume that this commit contains changes to the package.
-        return true;
-    };
-    !package_files.is_disjoint(&changed_files)
+    /// `hash` is only used for logging purposes.
+    fn are_changed_files_in_package(
+        &self,
+        package_path: &Utf8Path,
+        repository: &Repo,
+        hash: &str,
+    ) -> anyhow::Result<bool> {
+        // We run `cargo package` to get package files, which can edit files, such as `Cargo.lock`.
+        // Store its path so it can be reverted after comparison.
+        let cargo_lock_path = self
+            .get_cargo_lock_path(repository)
+            .context("failed to determine Cargo.lock path")?;
+        let package_files_res = get_package_files(package_path, repository);
+        if let Some(cargo_lock_path) = cargo_lock_path.as_deref() {
+            // Revert any changes to `Cargo.lock`
+            repository
+                .checkout(cargo_lock_path)
+                .context("cannot revert changes introduced when comparing packages")?;
+        }
+        let Ok(package_files) = package_files_res.inspect_err(|e| {
+            debug!("failed to get package files at commit {hash}: {e:?}");
+        }) else {
+            // `cargo package` can fail if the package doesn't contain a Cargo.toml file yet.
+            return Ok(true);
+        };
+        let Ok(changed_files) = repository.files_of_current_commit().inspect_err(|e| {
+            warn!("failed to get changed files of commit {hash}: {e:?}");
+        }) else {
+            // Assume that this commit contains changes to the package.
+            return Ok(true);
+        };
+        Ok(!package_files.is_disjoint(&changed_files))
+    }
 }
 
 /// Get files that belong to the package.


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
Close https://github.com/MarcoIeni/release-plz/issues/1791