### PR TITLE
fix: Correctly deserialize GitLab MR commits

### DIFF
--- a/crates/release_plz_core/src/git/backend.rs
+++ b/crates/release_plz_core/src/git/backend.rs
@@ -69,18 +69,17 @@ pub struct Author {
     pub login: String,
 }
 
+// https://docs.gitlab.com/ee/api/merge_requests.html#get-single-merge-request-commits
 #[derive(Deserialize, Clone, Debug)]
 pub struct GitLabMrCommit {
-    pub author: Option<GitLabAuthor>,
-    pub sha: String,
+    pub id: String,
 }
 
 impl From<GitLabMrCommit> for PrCommit {
     fn from(value: GitLabMrCommit) -> Self {
-        let author = value.author.map(|a| Author { login: a.username });
         PrCommit {
-            author,
-            sha: value.sha,
+            author: None,
+            sha: value.id,
         }
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
The response for `/api/v4/projects/:id/merge_requests/:merge_request_iid/commits` is described [in the documentation], and includes neither a `sha`, nor an `author` field.

[in the documentation]: https://docs.gitlab.com/ee/api/merge_requests.html#get-single-merge-request-commits

[As far as I can tell](https://github.com/MarcoIeni/release-plz/blob/7ef73f07dfce9fbf6a214bf1cbc2cab412155443/crates/release_plz_core/src/git/backend.rs#L570-L596) the `GitLabMrCommit` is only parsed from the `/api/v4/projects/:id/merge_requests/:merge_request_iid/commits` route, so the fields that are parsed have to be adjusted.

I  removed the author information, because the route described only gives `{author,committer}_name`, and `{author,committer}_email`, which are taken from the commit, and do not correlate to GitLab usernames. If it is fine to use the commit author name in place of the username, I can add it back in (I am not familiar with the rest of the codebase and do not know if using a "wrong" username would have any impact).