### PR TITLE
In Quickstart, release-plz-pr should "need" release-plz-release

### DIFF
--- a/website/docs/github/quickstart.md
+++ b/website/docs/github/quickstart.md
@@ -162,6 +162,7 @@ jobs:
   # and you want to update `Cargo.toml` versions and changelogs by yourself,
   # remove this job.
   release-plz-pr:
+    needs: [ release-plz-release ]
     name: Release-plz PR
     runs-on: ubuntu-latest
     # The concurrency block is explained below (after the code block).


### PR DESCRIPTION
It seems to me weird that these two actions race with one another. If release-plz-release somehow releases before release-plz-pr runs, a new release PR is created (because the local version equals the crates.io version). If release-plz-pr runs first, which is the most likely outcome, no PR is created.

Forcing an ordering between them removes this non-determinism and doesn't seem to do any harm.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/MarcoIeni/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
