### PR TITLE
fix: return error if default config has invalid toml

### DIFF
--- a/crates/release_plz/src/args/config_path.rs
+++ b/crates/release_plz/src/args/config_path.rs
@@ -45,7 +45,7 @@ impl ConfigPath {
             let path = Path::new(path);
             match load_config(path) {
                 Ok(Some(config)) => return Ok(config),
-                Ok(None) => continue,
+                Ok(None) => (),
                 Err(err) => return Err(err.context("invalid config file")),
             }
         }


### PR DESCRIPTION
Currently, if the TOML inside the default config files is invalid, the returned error is:

```
INFO release-plz config file not found, using default configuration
```

This is misleading, as the actual configuration might be malformed. We should propagate the error just like we do for the user-provided config file.