### PR TITLE
ci: remove deprecated macos-13 image

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,8 +36,6 @@ jobs:
             os: windows-2022
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
-          - target: x86_64-apple-darwin
-            os: macos-13
           - target: x86_64-pc-windows-msvc
             os: windows-2022
           - target: x86_64-unknown-linux-musl
@@ -47,7 +45,7 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-22.04
           - target: aarch64-apple-darwin
-            os: macos-13
+            os: macos-14
           - target: x86_64-unknown-freebsd
             os: ubuntu-22.04
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
           - os: windows-2022
           - os: ubuntu-22.04
           - os: macos-14
-          - os: macos-13
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/website/docs/extra/releasing-binaries.md
+++ b/website/docs/extra/releasing-binaries.md
@@ -74,15 +74,13 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-22.04
           - target: aarch64-apple-darwin
-            os: macos-13
+            os: macos-14
           - target: aarch64-pc-windows-msvc
             os: windows-2022
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-22.04
           - target: x86_64-unknown-linux-musl
             os: ubuntu-22.04
-          - target: x86_64-apple-darwin
-            os: macos-13
           - target: x86_64-pc-windows-msvc
             os: windows-2022
           - target: x86_64-unknown-freebsd


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
screenshot from https://github.com/actions/runner-images:
<img width="2404" height="524" alt="image" src="https://github.com/user-attachments/assets/b263e78f-eb9b-4777-9838-4c0be213c539" />
