### PR TITLE
Show full error message for trusted publishing token failure

### DIFF
--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -912,7 +912,7 @@ async fn release_package(
                     *trusted_publishing_client = Some(tp);
                 }
                 Err(e) => {
-                    warn!("Failed to use trusted publishing: {e}. Proceeding without it.");
+                    warn!("Failed to use trusted publishing: {e:#}. Proceeding without it.");
                 }
             }
         }


### PR DESCRIPTION
Currently the message doesn't contain enough details to actually diagnose problems with issuing a trusted publishing token. This makes it difficult to configure things correctly.

```
2025-11-28T21:26:57.890714Z  WARN Failed to use trusted publishing: Failed to retrieve token from Cargo registry. Proceeding without it.
```