### PR TITLE
specify cargo-binstall pkg-fmt for faster download

### DIFF
--- a/crates/release_plz/Cargo.toml
+++ b/crates/release_plz/Cargo.toml
@@ -60,6 +60,7 @@ toml_edit.workspace = true
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/release-plz-v{ version }/{ name }-{ target }{ archive-suffix }"
+pkg-fmt = "tgz"
 
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
 pkg-fmt = "zip"


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
