### PR TITLE
feat: Add documentation for Gitlab

### DIFF
--- a/website/docs/gitlab.md
+++ b/website/docs/gitlab.md
@@ -1,4 +1,4 @@
-# GitLab
+# GitLab CI
 
 `release-plz` can also run in GitLab CI/CD, however the setup is slightly more complex
 than with the Github CI.
@@ -21,7 +21,7 @@ to the CI/CD variables:
 6. The username can be converted to the email address using this format:
    `$USERNAME@noreply.gitlab.com`
 7. Configure this email address as a variable named `RELEASE_PLZ_BOT_EMAIL` in
-   Settings -> CI?CD -> Variables -> Add variable
+   Settings -> CI/CD -> Variables -> Add variable
 
 ## 2. Put the component definition in a repository
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -47,6 +47,7 @@ const sidebars = {
         "github/persist-credentials",
       ],
     },
+    "gitlab",
     "config",
     {
       type: "category",


### PR DESCRIPTION
Document how to use `release-plz` in Gitlab CI/CD.

This provides a component that users can reuse between their repositories.

Closes #2174 