### PR TITLE
fix: correctly recognize when crate already published

### DIFF
--- a/crates/release_plz_core/src/command/release.rs
+++ b/crates/release_plz_core/src/command/release.rs
@@ -953,9 +953,6 @@ async fn release_package(
             || output.stderr.contains("error:")
         {
             if is_already_published(&output, release_info) {
-                // The crate was published while `cargo publish` was running.
-                // Note that the crate wasn't published yet when `cargo publish` started,
-                // otherwise `cargo` would have returned the error "crate {package}@{version} already exists"
                 info!(
                     "skipping publish of {} {}: already published",
                     release_info.package.name, release_info.package.version
@@ -1003,8 +1000,15 @@ async fn release_package(
 }
 
 fn is_already_published(output: &CmdOutput, release_info: &ReleaseInfo<'_>) -> bool {
-    let already_uploaded_message =
-        format!("crate version `{}` is already uploaded", &release_info.package.version);
+    // Error happening if the crate was published while `cargo publish` was running.
+    let already_uploaded_message = format!(
+        "crate version `{}` is already uploaded",
+        &release_info.package.version
+    );
+
+    // Previously, I thought that this error
+    // would happen only if the crate wasn't published yet when `cargo publish` started,
+    // but then I saw this error in CI while releasing the crate for the first time.
     let already_exists_message = format!(
         "crate {}@{} already exists",
         release_info.package.name, release_info.package.version


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
this happened while releasing release-plz itself:
<img width="2580" height="1064" alt="image" src="https://github.com/user-attachments/assets/c9dec228-07f0-4b38-be73-92564cab4222" />
