### PR TITLE
fix: Improve error message for committed file that is in .gitignore

### DIFF
--- a/crates/git_cmd/README.md
+++ b/crates/git_cmd/README.md
@@ -4,4 +4,4 @@
 [![Docs.rs](https://docs.rs/git_cmd/badge.svg)](https://docs.rs/git_cmd)
 [![CI](https://github.com/release-plz/release-plz/workflows/CI/badge.svg)](https://github.com/release-plz/release-plz/actions)
 
-Run git as shell shell and parse its stdout.
+Run git as shell and parse its stdout.

--- a/crates/git_cmd/src/lib.rs
+++ b/crates/git_cmd/src/lib.rs
@@ -78,7 +78,9 @@ impl Repo {
         let changes = self.changes_except_typechanges()?;
         anyhow::ensure!(
             changes.is_empty(),
-            "the working directory of this project has uncommitted changes. If these files are both committed and in .gitignore, either delete them or remove them from .gitignore. Otherwise, please commit or stash these changes:\n{changes:?}"
+            "the working directory of this project has uncommitted changes. If these files are both committed and in .gitignore, either delete them or remove them from .gitignore.\n\
+             If the list includes submodules, run `git ls-files -ci --exclude-standard` in the submodule to check if files in the submodule are both committed and in .gitignore.\n\
+             Otherwise, please commit or stash these changes:\n{changes:?}"
         );
         Ok(())
     }


### PR DESCRIPTION
The new message explains that this also can apply to submodules and provides a command to list offending files, as the error is not able to list offending files for submodules.

Old error:
```
the working directory of this project has uncommitted changes. If these files are both committed and in .gitignore, either delete them or remove them from .gitignore. Otherwise, please commit or stash these changes:
["protobuf"]
```

New error:
```
the working directory of this project has uncommitted changes. If these files are both committed and in .gitignore, either delete them or remove them from .gitignore.
If the list includes submodules, run `git ls-files -ci --exclude-standard` in the submodule to check if files in the submodule are both committed and in .gitignore.
Otherwise, please commit or stash these changes:
["protobuf"]
```

Where `protobuf` is a submodule where `git ls-files -ci --exclude-standard` returns the following list:
```
src/solaris/libstdc++.la
```

Fixes #2643
