### PR TITLE
docs: Mention pull-requests read permission in quickstart docs

### DIFF
--- a/website/docs/github/quickstart.md
+++ b/website/docs/github/quickstart.md
@@ -206,9 +206,9 @@ jobs:
     name: Release-plz PR
     runs-on: ubuntu-latest
     permissions:
-      # Used to push to the pull request branch.
+      # Push to the pull request branch.
       contents: write
-      # Used to create and update pull requests.
+      # Create and update pull requests.
       pull-requests: write
 
     # The concurrency block is explained below (after the code block).


### PR DESCRIPTION
This fixes what I think is a little oversight in the quick-start example for GitHub actions

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/release-plz/release-plz/blob/main/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test`
-->
