### PR TITLE
fix(ci): exclude flaky and unresolvable URLs from lychee link checks

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -15,4 +15,6 @@ exclude = [
   # Don't check pull request links to avoid being rate limited
   'https://github.com/release-plz/release-plz/pull/*',
   'https://github.com/release-plz/release-plz/issues/*',
+  # GitHub search returns 502 intermittently
+  'https://github.com/search*',
 ]

--- a/website/docs/github/token.md
+++ b/website/docs/github/token.md
@@ -92,7 +92,7 @@ request and the commit itself.
 If you don't want release-plz to open release pull requests and commit with
 your account, consider creating a
 [machine user](https://docs.github.com/en/get-started/learning-about-github/types-of-github-accounts#user-accounts).
-If your machine user needs a cool avatar, you can use the release-plz [logo](/img/robot_head.jpeg).
+If your machine user needs a cool avatar, you can use the release-plz [logo](https://release-plz.dev/img/robot_head.jpeg).
 :::
 
 Create the PAT, choosing one of the two types:
@@ -174,7 +174,7 @@ Here's how to use a GitHub App to generate a GitHub token:
    - If you use [protected tags](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules):
      Under `Repository permissions: Administration` select `Access: Read & write`.
    - (Optional) Under `Where can this GitHub App be installed?` select `Only on this account`.
-   - (Optional) Set the release-plz [logo](/img/robot_head.jpeg).
+   - (Optional) Set the release-plz [logo](https://release-plz.dev/img/robot_head.jpeg).
 
 2. Create a Private key from the App settings page and store it securely.
 


### PR DESCRIPTION
## Summary

The PR Links workflow fails on every PR due to two pre-existing issues:

1. **GitHub search URLs return 502 intermittently** — `https://github.com/search?type=code&q=...` links in `README.md` and `release-plz-in-the-wild.md` hit transient 502 Bad Gateway errors
2. **Root-relative Docusaurus image paths** — `/img/robot_head.jpeg` in `website/docs/github/token.md` can't be resolved by lychee

Fixes:
- Add `https://github.com/search*` to the `exclude` list in `lychee.toml`
- Replace root-relative `/img/robot_head.jpeg` links in `token.md` with absolute `https://release-plz.dev/img/robot_head.jpeg` URLs

## Evidence

Every recent PR fails the link check for the same reasons:

```
[502] https://github.com/search?type=code&q=path%3A*.yml+OR+path%3A*.yaml+release-plz%2Faction%40
[ERROR] Cannot convert path '/img/robot_head.jpeg' to a URI
```