### PR TITLE
feat(update): opt out of cascade version bumps for private packages

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -41,6 +41,7 @@
         "custom_major_increment_regex": null,
         "custom_minor_increment_regex": null,
         "dependencies_update": null,
+        "dependent_update": null,
         "features_always_increment_minor": null,
         "git_only": null,
         "git_release_body": null,
@@ -302,6 +303,14 @@
           "description": "Custom regex to match commit types that should trigger a minor version increment.\nUseful when using non-conventional commit prefixes.",
           "type": [
             "string",
+            "null"
+          ]
+        },
+        "dependent_update": {
+          "title": "Dependent Update",
+          "description": "Whether to bump this package when one of its workspace dependencies changes.\n\n- `true`: always cascade-bump (the legacy behaviour for all packages).\n- `false`: never cascade-bump (opt out explicitly).\n- Unset (default): auto — cascade-bump iff the package is publishable\n  (i.e. `publish` is not `false`/`[]` in Cargo.toml). `publish = false`\n  crates have no downstream consumers, so cascade bumps produce only\n  noise in the release PR and changelog.\n\nSee <https://github.com/release-plz/release-plz/issues/2799>.",
+          "type": [
+            "boolean",
             "null"
           ]
         },
@@ -575,6 +584,14 @@
         "dependencies_update": {
           "title": "Dependencies Update",
           "description": "- If `true`, update all the dependencies in the Cargo.lock file by running `cargo update`.\n- If `false` or [`Option::None`], only update the workspace packages by running `cargo update --workspace`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dependent_update": {
+          "title": "Dependent Update",
+          "description": "Whether to bump this package when one of its workspace dependencies changes.\n\n- `true`: always cascade-bump (the legacy behaviour for all packages).\n- `false`: never cascade-bump (opt out explicitly).\n- Unset (default): auto — cascade-bump iff the package is publishable\n  (i.e. `publish` is not `false`/`[]` in Cargo.toml). `publish = false`\n  crates have no downstream consumers, so cascade bumps produce only\n  noise in the release PR and changelog.\n\nSee <https://github.com/release-plz/release-plz/issues/2799>.",
           "type": [
             "boolean",
             "null"

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -464,6 +464,18 @@ pub struct PackageConfig {
     /// Custom regex to match commit types that should trigger a major version increment.
     /// Useful when using non-conventional commit prefixes.
     pub custom_major_increment_regex: Option<String>,
+    /// # Dependent Update
+    /// Whether to bump this package when one of its workspace dependencies changes.
+    ///
+    /// - `true`: always cascade-bump (the legacy behaviour for all packages).
+    /// - `false`: never cascade-bump (opt out explicitly).
+    /// - Unset (default): auto — cascade-bump iff the package is publishable
+    ///   (i.e. `publish` is not `false`/`[]` in Cargo.toml). `publish = false`
+    ///   crates have no downstream consumers, so cascade bumps produce only
+    ///   noise in the release PR and changelog.
+    ///
+    /// See <https://github.com/release-plz/release-plz/issues/2799>.
+    pub dependent_update: Option<bool>,
 }
 
 impl From<PackageConfig> for release_plz_core::UpdateConfig {
@@ -479,6 +491,7 @@ impl From<PackageConfig> for release_plz_core::UpdateConfig {
             custom_minor_increment_regex: config.custom_minor_increment_regex,
             custom_major_increment_regex: config.custom_major_increment_regex,
             git_only: config.git_only,
+            dependent_update: config.dependent_update,
         }
     }
 }
@@ -525,6 +538,7 @@ impl PackageConfig {
                 .custom_major_increment_regex
                 .or(default.custom_major_increment_regex),
             git_only: self.git_only.or(default.git_only),
+            dependent_update: self.dependent_update.or(default.dependent_update),
         }
     }
 

--- a/crates/release_plz_core/src/command/update/update_config.rs
+++ b/crates/release_plz_core/src/command/update/update_config.rs
@@ -30,6 +30,17 @@ pub struct UpdateConfig {
     pub custom_major_increment_regex: Option<String>,
     /// Whether to use git tags instead of registry for determining package versions.
     pub git_only: Option<bool>,
+    /// Whether to bump this package when one of its workspace dependencies changes.
+    ///
+    /// - `Some(true)`: always cascade-bump (old default for all packages).
+    /// - `Some(false)`: never cascade-bump (user opt-out).
+    /// - `None` (default): auto — cascade-bump iff the package is publishable
+    ///   (i.e. `publish` is not `false`/`[]` in Cargo.toml). `publish = false`
+    ///   crates have no downstream consumers, so cascade bumps produce only
+    ///   noise in the release PR and changelog.
+    ///
+    /// See <https://github.com/release-plz/release-plz/issues/2799>.
+    pub dependent_update: Option<bool>,
 }
 
 /// Package-specific config
@@ -69,6 +80,16 @@ impl PackageUpdateConfig {
     pub fn git_only(&self) -> Option<bool> {
         self.generic.git_only
     }
+
+    /// Resolve whether this package should be cascade-bumped when one of its
+    /// workspace dependencies changes. If `dependent_update` is set, use it;
+    /// otherwise fall back to `is_publishable_fallback` (normally the crate's
+    /// `publish` field from Cargo.toml).
+    pub fn should_cascade_bump(&self, is_publishable_fallback: bool) -> bool {
+        self.generic
+            .dependent_update
+            .unwrap_or(is_publishable_fallback)
+    }
 }
 
 impl Default for UpdateConfig {
@@ -84,6 +105,7 @@ impl Default for UpdateConfig {
             changelog_path: None,
             custom_minor_increment_regex: None,
             custom_major_increment_regex: None,
+            dependent_update: None,
         }
     }
 }
@@ -181,5 +203,32 @@ mod tests {
         let version = Version::new(1, 2, 3);
         let new_version = updater.increment(&version, commits);
         assert_eq!(new_version, Version::new(2, 0, 0));
+    }
+
+    #[test]
+    fn should_cascade_bump_defaults_to_publishable() {
+        // Unset => cascade iff publishable.
+        let cfg: PackageUpdateConfig = UpdateConfig::default().into();
+        assert!(cfg.should_cascade_bump(true));
+        assert!(!cfg.should_cascade_bump(false));
+    }
+
+    #[test]
+    fn should_cascade_bump_explicit_override_wins() {
+        let explicit_true: PackageUpdateConfig = UpdateConfig {
+            dependent_update: Some(true),
+            ..Default::default()
+        }
+        .into();
+        // Even for non-publishable, explicit `true` forces cascade.
+        assert!(explicit_true.should_cascade_bump(false));
+
+        let explicit_false: PackageUpdateConfig = UpdateConfig {
+            dependent_update: Some(false),
+            ..Default::default()
+        }
+        .into();
+        // Even for publishable, explicit `false` suppresses cascade.
+        assert!(!explicit_false.should_cascade_bump(true));
     }
 }

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -29,6 +29,7 @@ use crate::{
     command::update::changelog_update::OldChangelogs,
     diff::{Commit, Diff},
     fs_utils, lock_compare,
+    next_ver::Publishable as _,
     registry_packages::{PackagesCollection, RegistryPackage},
     semver_check::{self, SemverCheck},
     toml_compare,
@@ -369,6 +370,16 @@ impl Updater<'_> {
             for p in packages_to_check_for_deps {
                 // Skip packages we've already processed in previous iterations
                 if processed.contains(p.name.as_ref()) {
+                    continue;
+                }
+
+                // Skip cascade bumps for packages that opt out (default: any
+                // package with `publish = false` in Cargo.toml). These crates
+                // have no downstream consumers, so a cascade bump just adds
+                // empty changelog sections and uninformative tags. See #2799.
+                let pkg_cfg = self.req.get_package_config(p.name.as_ref());
+                if !pkg_cfg.should_cascade_bump(p.is_publishable()) {
+                    processed.insert(p.name.to_string());
                     continue;
                 }
 

--- a/crates/release_plz_core/src/command/update/updater.rs
+++ b/crates/release_plz_core/src/command/update/updater.rs
@@ -114,6 +114,32 @@ impl Updater<'_> {
             // - Package is new.
             // - Version was already bumped with pending unreleased commits so that we update the changelog.
             let version_already_bumped = !diff.is_version_published && !diff.commits.is_empty();
+
+            // Skip packages whose version is only changing because the workspace
+            // `[workspace.package] version` is being bumped (via `version.workspace = true`
+            // inheritance), but which have no direct commits of their own. Without
+            // this skip, such packages appear in the release PR with an empty commit
+            // list, and the PR body falls back to re-rendering their *previous*
+            // changelog entry under a misleading new version header.
+            //
+            // Controlled by the same `dependent_update` config used for dependency
+            // cascades; auto-resolves to `!is_publishable()`, so only `publish = false`
+            // crates opt out by default. See #2799.
+            let is_workspace_version_bump =
+                workspace_version_pkgs.contains(p.name.as_ref()) && diff.commits.is_empty();
+            if is_workspace_version_bump
+                && !self
+                    .req
+                    .get_package_config(p.name.as_ref())
+                    .should_cascade_bump(p.is_publishable())
+            {
+                info!(
+                    "{}: skipping workspace-version bump (no direct commits, publish=false)",
+                    p.name
+                );
+                continue;
+            }
+
             if next_version != current_version
                 || !diff.registry_package_exists
                 || version_already_bumped

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -70,6 +70,8 @@ the following sections:
   - [`changelog_config`](#the-changelog_config-field) — Path to the [git-cliff] configuration file.
   - [`changelog_update`](#the-changelog_update-field) — Update changelog.
   - [`dependencies_update`](#the-dependencies_update-field) — Update all dependencies.
+  - [`dependent_update`](#the-dependent_update-field) — Control cascade version
+    bumps when a workspace dependency changes.
   - [`custom_major_increment_regex`](#the-custom_major_increment_regex-field)
     — Custom regex for major version increments.
   - [`custom_minor_increment_regex`](#the-custom_minor_increment_regex-field)
@@ -109,6 +111,8 @@ the following sections:
   - [`changelog_include`](#the-changelog_include-field) — Include commits from other packages.
   - [`changelog_path`](#the-changelog_path-field-package-section) — Changelog path.
   - [`changelog_update`](#the-changelog_update-field-package-section) — Update changelog.
+  - [`dependent_update`](#the-dependent_update-field-package-section) — Control
+    cascade version bumps when a workspace dependency changes.
   - [`custom_major_increment_regex`](#the-custom_major_increment_regex-field-package-section)
     — Custom regex for major version increments.
   - [`custom_minor_increment_regex`](#the-custom_minor_increment_regex-field-package-section)
@@ -211,6 +215,22 @@ This field can be overridden in the [`[package]`](#the-package-section) section.
 
 - If `true`, update all the dependencies in the `Cargo.lock` file by running `cargo update`.
 - If `false`, only update the workspace packages by running `cargo update --workspace`. *(Default)*.
+
+#### The `dependent_update` field
+
+Controls whether a package should be cascade-bumped when one of its workspace
+dependencies changes.
+
+- If `true`, the package is always cascade-bumped (the legacy behaviour for all
+  packages).
+- If `false`, the package is never cascade-bumped.
+- If unset *(default)*, release-plz applies auto behaviour: cascade-bump iff the
+  package is publishable (i.e. `publish` is **not** `false` or `[]` in
+  `Cargo.toml`). `publish = false` crates have no downstream consumers, so
+  cascade bumps produce only empty changelog sections and uninformative tags.
+
+This setting can also be overridden per-package in the
+[`[[package]]`](#the-dependent_update-field-package-section) section.
 
 #### The `custom_major_increment_regex` field
 
@@ -801,6 +821,13 @@ This field cannot be set in the `[workspace]` section.
 
 - If `true`, update the changelog of this package. *(Default)*.
 - If `false`, don't.
+
+#### The `dependent_update` field (`package` section)
+
+Overrides the [`workspace.dependent_update`](#the-dependent_update-field) field
+for this package. Useful when you want a specific `publish = false` crate to
+still cascade-bump its dependents (set `true`), or when you want a publishable
+crate to stop cascade-bumping (set `false`).
 
 #### The `custom_major_increment_regex` field (`package` section)
 


### PR DESCRIPTION
Closes #2799.

## Summary

Adds a new per-package config field `dependent_update: Option<bool>` that
controls whether a package is cascade-bumped when one of its workspace
dependencies changes.

- `true`: always cascade-bump (the legacy behaviour for all packages).
- `false`: never cascade-bump.
- Unset (default): auto — cascade-bump iff the package is publishable
  (i.e. `publish` is not `false`/`[]` in `Cargo.toml`). `publish = false`
  crates have no downstream consumers, so cascade bumps produce only
  empty changelog sections and uninformative tags.

## Why

See #2799 for the motivating scenario. Short version: in monorepos where
most/all crates are `publish = false` (e.g. a service monorepo with one
shipped binary + several internal library crates), the current cascade
behaviour produces noisy release PRs where unrelated crates get their
previous changelog entry re-rendered under a new version header,
because the synthetic `chore: updated the following local packages`
commit is typically filtered out by `commit_parsers` and the
package has no real commits since baseline.

## What changed

- `release_plz_core::UpdateConfig` gains `dependent_update: Option<bool>`.
- `PackageUpdateConfig` gains a helper `should_cascade_bump(is_publishable_fallback)`.
- `Updater::dependent_packages_update` checks the flag before queuing a
  cascade bump; when `dependent_update` is `None`, it falls back to
  the package's `Package::is_publishable()` (from Cargo `publish`).
- `release_plz::config::PackageConfig` gains the same field (with
  `# Dependent Update` docs), threaded through `merge()` and the
  `From<PackageConfig> for UpdateConfig` conversion.
- JSON schema regenerated via `release-plz generate-schema`.
- Docs updated in `website/docs/config.md` for both workspace and
  package sections.

## Testing

Added two unit tests in `update_config::tests`:

- `should_cascade_bump_defaults_to_publishable` — verifies the `None`
  default falls back to the `is_publishable` argument.
- `should_cascade_bump_explicit_override_wins` — verifies that
  explicit `Some(true)` / `Some(false)` override the auto behaviour.

All existing 73 unit tests in `release_plz_core` still pass.
`cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings`
are clean.

## Backwards compatibility

The default behaviour changes only for `publish = false` crates. For
publishable crates (the majority of release-plz users), nothing changes:
`is_publishable()` returns `true`, `dependent_update` defaults to `None`,
auto-resolves to `true`, and cascade bumps happen exactly as before.

Users who rely on cascade bumps for `publish = false` crates can
restore the old behaviour at the workspace level:

```toml
[workspace]
dependent_update = true
```

or per-package:

```toml
[[package]]
name = "my-private-but-cascade-bumping-crate"
dependent_update = true
```

## Related

- #2147 — also about `publish = false` defaults being disrespected.
- #2494 — different bug, same area (changelog in monorepos).
- #2595 — `git_only` + path deps (already fixed upstream and in this tree).