### PR TITLE
feat(changelog): add workspace_changelog aggregated changelog option

### DIFF
--- a/.schema/latest.json
+++ b/.schema/latest.json
@@ -67,7 +67,8 @@
         "release_always": null,
         "release_commits": null,
         "repo_url": null,
-        "semver_check": null
+        "semver_check": null,
+        "workspace_changelog": null
       }
     }
   },
@@ -802,6 +803,14 @@
           "description": "Controls when to run cargo-semver-checks.\nIf unspecified, run cargo-semver-checks if the package is a library.",
           "type": [
             "boolean",
+            "null"
+          ]
+        },
+        "workspace_changelog": {
+          "title": "Workspace Changelog",
+          "description": "Path to the aggregated workspace-wide changelog file, relative to the workspace root.\nWhen set, instead of writing per-crate CHANGELOG.md files, all package changes are\ncollected into a single file grouped by package name.\nExample: `workspace_changelog = \"CHANGELOG.md\"`",
+          "type": [
+            "string",
             "null"
           ]
         }

--- a/crates/release_plz/src/config.rs
+++ b/crates/release_plz/src/config.rs
@@ -61,6 +61,10 @@ impl Config {
         }
         let mut update_request =
             update_request.with_default_package_config(default_update_config.into());
+        if let Some(ref path) = self.workspace.workspace_changelog {
+            let path = to_utf8_pathbuf(path.clone())?;
+            update_request = update_request.with_workspace_changelog(path);
+        }
         for (package, config) in self.packages() {
             let mut update_config = config.clone();
             update_config = update_config.merge(self.workspace.packages_defaults.clone());
@@ -215,6 +219,12 @@ pub struct Workspace {
     #[serde(default = "default_max_analyze_commits")]
     #[schemars(default = "default_max_analyze_commits")]
     pub max_analyze_commits: Option<u32>,
+    /// # Workspace Changelog
+    /// Path to the aggregated workspace-wide changelog file, relative to the workspace root.
+    /// When set, instead of writing per-crate CHANGELOG.md files, all package changes are
+    /// collected into a single file grouped by package name.
+    /// Example: `workspace_changelog = "CHANGELOG.md"`
+    pub workspace_changelog: Option<PathBuf>,
 }
 
 impl Default for Workspace {
@@ -234,6 +244,7 @@ impl Default for Workspace {
             release_commits: None,
             release_always: None,
             max_analyze_commits: default_max_analyze_commits(),
+            workspace_changelog: None,
         }
     }
 }
@@ -590,6 +601,7 @@ mod tests {
         Config {
             changelog: ChangelogCfg::default(),
             workspace: Workspace {
+                workspace_changelog: None,
                 dependencies_update: Some(false),
                 changelog_config: Some("../git-cliff.toml".into()),
                 allow_dirty: Some(false),
@@ -713,6 +725,7 @@ mod tests {
         let config = Config {
             changelog: ChangelogCfg::default(),
             workspace: Workspace {
+                workspace_changelog: None,
                 dependencies_update: None,
                 changelog_config: Some("../git-cliff.toml".into()),
                 allow_dirty: None,

--- a/crates/release_plz_core/src/command/update/mod.rs
+++ b/crates/release_plz_core/src/command/update/mod.rs
@@ -129,12 +129,99 @@ fn update_changelogs(
     update_request: &UpdateRequest,
     local_packages: &PackagesUpdate,
 ) -> anyhow::Result<()> {
+    // When workspace_changelog_path is set, aggregate all packages into one file.
+    if let Some(ws_path) = update_request.workspace_changelog_path() {
+        return update_workspace_changelog(update_request, local_packages, ws_path);
+    }
+    // Default: write per-crate CHANGELOG.md.
     for (package, update) in local_packages.updates() {
         if let Some(changelog) = update.changelog.as_ref() {
             let changelog_path = update_request.changelog_path(package);
             fs_err::write(&changelog_path, changelog).context("cannot write changelog")?;
         }
     }
+    Ok(())
+}
+
+fn update_workspace_changelog(
+    update_request: &UpdateRequest,
+    local_packages: &PackagesUpdate,
+    ws_changelog_path: &Utf8Path,
+) -> anyhow::Result<()> {
+    use chrono::Utc;
+
+    // Collect non-empty new changelog entries sorted by package name.
+    let mut pkg_entries: Vec<(String, String, cargo_metadata::semver::Version)> = local_packages
+        .updates()
+        .iter()
+        .filter_map(|(pkg, update)| {
+            update.new_changelog_entry.as_ref().and_then(|e| {
+                let trimmed = e.trim().to_string();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some((pkg.name.to_string(), trimmed, update.version.clone()))
+                }
+            })
+        })
+        .collect();
+
+    if pkg_entries.is_empty() {
+        return Ok(());
+    }
+
+    pkg_entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // Determine the release version: use max version across all updated packages.
+    let version = pkg_entries
+        .iter()
+        .map(|(_, _, v)| v)
+        .max()
+        .cloned()
+        .unwrap_or_else(|| cargo_metadata::semver::Version::new(0, 0, 0));
+
+    let date = Utc::now().format("%Y-%m-%d");
+    let mut new_entry = format!("## v{version} — {date}\n\n");
+
+    for (pkg_name, entry, _) in &pkg_entries {
+        new_entry.push_str(&format!("### {pkg_name}\n"));
+        // Demote package-level heading sections: ### Foo → #### Foo
+        for line in entry.lines() {
+            if let Some(rest) = line.strip_prefix("### ") {
+                new_entry.push_str(&format!("#### {rest}\n"));
+            } else {
+                new_entry.push_str(line);
+                new_entry.push('\n');
+            }
+        }
+        new_entry.push('\n');
+    }
+
+    // Resolve path relative to workspace root (parent of local_manifest).
+    let abs_path = update_request
+        .local_manifest()
+        .parent()
+        .context("cannot determine workspace root from local manifest path")?
+        .join(ws_changelog_path);
+
+    let existing = if abs_path.exists() {
+        fs_err::read_to_string(&abs_path)?
+    } else {
+        String::new()
+    };
+
+    const HEADER: &str = "# Changelog\n\n";
+    let body = existing.strip_prefix(HEADER).unwrap_or(existing.as_str());
+
+    // Separate from previous entry with a horizontal rule.
+    let separator = if body.trim().is_empty() {
+        String::new()
+    } else {
+        "---\n\n".to_string()
+    };
+
+    let new_content = format!("{HEADER}{new_entry}{separator}{body}");
+    fs_err::write(&abs_path, new_content).context("cannot write workspace changelog")?;
     Ok(())
 }
 

--- a/crates/release_plz_core/src/command/update/update_request.rs
+++ b/crates/release_plz_core/src/command/update/update_request.rs
@@ -48,6 +48,9 @@ pub struct UpdateRequest {
     release_commits: Option<Regex>,
     git: Option<GitForge>,
     max_analyze_commits: Option<u32>,
+    /// When set, all package changelogs are aggregated into this single file
+    /// instead of writing per-crate CHANGELOG.md files.
+    workspace_changelog_path: Option<Utf8PathBuf>,
 }
 
 impl UpdateRequest {
@@ -68,6 +71,7 @@ impl UpdateRequest {
             release_commits: None,
             git: None,
             max_analyze_commits: None,
+            workspace_changelog_path: None,
         })
     }
 
@@ -245,6 +249,15 @@ impl UpdateRequest {
 
     pub fn release_commits(&self) -> Option<&Regex> {
         self.release_commits.as_ref()
+    }
+
+    pub fn workspace_changelog_path(&self) -> Option<&Utf8Path> {
+        self.workspace_changelog_path.as_deref()
+    }
+
+    pub fn with_workspace_changelog(mut self, path: Utf8PathBuf) -> Self {
+        self.workspace_changelog_path = Some(path);
+        self
     }
 
     /// Determine if `git_only` mode should be used for a specific package.


### PR DESCRIPTION
Closes #2791.

## Summary

Adds a new optional `workspace_changelog = "<path>"` field to the `[workspace]`
section. When set, release-plz writes a single aggregated `CHANGELOG.md` at the
given path instead of per-crate `CHANGELOG.md` files. Entries are grouped by
package name with `### <package>` subsections and the standard commit group
headings (`### Added`, `### Fixed`, …) demoted to `####` inside each package
block. Releases are separated by a horizontal rule (`---`).

When the field is **not** set, release-plz keeps its current per-crate
changelog behaviour — this is purely additive.

## Why

In `git_only` monorepos (and some polyglot repos) the per-crate changelog is
convenient for library consumers but awkward for humans reading release notes
— every release forces you to open N files to see \"what shipped in v0.3.20\".
A single aggregated file groups everything under one version header, which is
what most users actually want when reading release notes on the repo home
page or in a GitHub Release body.

I'm happy to drop this if it's not a direction the project wants to take
— please feel free to close. We're already using it in a downstream fork
and opening this mainly in case it's useful to other monorepo users.

## Example output

```markdown
# Changelog

## v0.3.4 — 2026-04-13

### my-core
#### Added
- (schema) LabelSchema persistence and B-tree unique index

### my-embed
#### Testing
- Unique constraint enforced after database reopen

---

## v0.3.3 — 2026-03-15
...
```

## What changed

- `release_plz_core::update_request::UpdateRequest` gains a
  `workspace_changelog_path: Option<Utf8PathBuf>` and a
  `with_workspace_changelog(path)` builder method.
- `release_plz_core::command::update::mod` writes to that path instead of
  per-crate files when it is set; headings are demoted and entries grouped
  by package.
- `release_plz::config::Workspace` gains `workspace_changelog: Option<PathBuf>`
  plumbed through `fill_update_config`.
- JSON schema regenerated via `release-plz generate-schema`.

## Testing

`cargo clippy --workspace --all-targets -- -D warnings` and
`cargo fmt --check` are clean. All existing 92 library unit tests in
`release_plz_core` / `release_plz` pass unchanged.

The feature has been running for ~2 weeks in our downstream monorepo
(coordinode) against our fork of release-plz.

## Alternatives considered

- Post-process per-crate `CHANGELOG.md` files with an external script — this
  is what we did for a while, but the output is second-class (doesn't land in
  release PR body, doesn't appear in `git log` at merge time, etc.).
- Emit both per-crate **and** workspace changelog — rejected for now to keep
  the diff minimal; could be added later as a toggle if users ask.

## Backwards compatibility

Fully backwards compatible. The new field defaults to `None`; existing configs
behave exactly as before.